### PR TITLE
♻️ add body type on generate-document endpoint

### DIFF
--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -153,4 +153,10 @@ class TemplateSerializer(BaseResourceSerializer):
 class DocumentGenerationSerializer(serializers.Serializer):
     """Serializer to receive a request to generate a document on a template."""
 
-    body = serializers.CharField(label=_("Markdown Body"))
+    body = serializers.CharField(label=_("Body"))
+    body_type = serializers.ChoiceField(
+        choices=["html", "markdown"],
+        label=_("Body type"),
+        required=False,
+        default="html",
+    )

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -372,9 +372,10 @@ class TemplateViewSet(
             )
 
         body = serializer.validated_data["body"]
+        body_type = serializer.validated_data["body_type"]
 
         template = self.get_object()
-        pdf_content = template.generate_document(body)
+        pdf_content = template.generate_document(body, body_type)
 
         response = FileResponse(BytesIO(pdf_content), content_type="application/pdf")
         response["Content-Disposition"] = f"attachment; filename={template.title}.pdf"

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -361,17 +361,21 @@ class Template(BaseModel):
             "retrieve": can_get,
         }
 
-    def generate_document(self, body):
+    def generate_document(self, body, body_type):
         """
         Generate and return a PDF document for this template around the
-        markdown body passed as argument.
+        body passed as argument.
         """
         document = frontmatter.loads(body)
         metadata = document.metadata
-        markdown_body = document.content.strip()
-        body_html = (
-            markdown.markdown(textwrap.dedent(markdown_body)) if markdown_body else ""
-        )
+        strip_body = document.content.strip()
+
+        if body_type == "html":
+            body_html = strip_body
+        else:
+            body_html = (
+                markdown.markdown(textwrap.dedent(strip_body)) if strip_body else ""
+            )
 
         document_html = HTML(
             string=DjangoTemplate(self.code).render(

--- a/src/backend/core/tests/templates/test_api_templates_generate_document.py
+++ b/src/backend/core/tests/templates/test_api_templates_generate_document.py
@@ -114,3 +114,67 @@ def test_api_templates_generate_document_related(via, mock_user_get_teams):
 
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/pdf"
+
+
+def test_api_templates_generate_document_type_html():
+    """Generate pdf document with the body type html."""
+    user = factories.UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    template = factories.TemplateFactory(is_public=True)
+    data = {"body": "<p>Test body</p>", "body_type": "html"}
+
+    response = client.post(
+        f"/api/v1.0/templates/{template.id!s}/generate-document/",
+        data,
+        format="json",
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/pdf"
+
+
+def test_api_templates_generate_document_type_markdown():
+    """Generate pdf document with the body type markdown."""
+    user = factories.UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    template = factories.TemplateFactory(is_public=True)
+    data = {"body": "# Test markdown body", "body_type": "markdown"}
+
+    response = client.post(
+        f"/api/v1.0/templates/{template.id!s}/generate-document/",
+        data,
+        format="json",
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/pdf"
+
+
+def test_api_templates_generate_document_type_unknown():
+    """Generate pdf document with the body type unknown."""
+    user = factories.UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    template = factories.TemplateFactory(is_public=True)
+    data = {"body": "# Test markdown body", "body_type": "unknown"}
+
+    response = client.post(
+        f"/api/v1.0/templates/{template.id!s}/generate-document/",
+        data,
+        format="json",
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "body_type": [
+            '"unknown" is not a valid choice.',
+        ]
+    }

--- a/src/frontend/apps/impress/src/features/pads/pad-tools/api/useCreatePdf.tsx
+++ b/src/frontend/apps/impress/src/features/pads/pad-tools/api/useCreatePdf.tsx
@@ -2,21 +2,24 @@ import { useMutation } from '@tanstack/react-query';
 
 import { APIError, errorCauses, fetchAPI } from '@/api';
 
-interface CreatePdfFromMarkdownParams {
+interface CreatePdfParams {
   templateId: string;
-  markdown: string;
+  body: string;
+  body_type: 'html' | 'markdown';
 }
 
-export const createPdfFromMarkdown = async ({
+export const createPdf = async ({
   templateId,
-  markdown,
-}: CreatePdfFromMarkdownParams): Promise<Blob> => {
+  body,
+  body_type,
+}: CreatePdfParams): Promise<Blob> => {
   const response = await fetchAPI(
     `templates/${templateId}/generate-document/`,
     {
       method: 'POST',
       body: JSON.stringify({
-        body: markdown,
+        body,
+        body_type,
       }),
     },
   );
@@ -28,8 +31,8 @@ export const createPdfFromMarkdown = async ({
   return await response.blob();
 };
 
-export function useCreatePdfFromMarkdown() {
-  return useMutation<Blob, APIError, CreatePdfFromMarkdownParams>({
-    mutationFn: createPdfFromMarkdown,
+export function useCreatePdf() {
+  return useMutation<Blob, APIError, CreatePdfParams>({
+    mutationFn: createPdf,
   });
 }

--- a/src/frontend/apps/impress/src/features/pads/pad-tools/components/PrintToPDFButton.tsx
+++ b/src/frontend/apps/impress/src/features/pads/pad-tools/components/PrintToPDFButton.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 
 import { Pad, usePadStore } from '@/features/pads/pad';
 
-import { useCreatePdfFromMarkdown } from '../api/useCreatePdfFromMarkdown';
+import { useCreatePdf } from '../api/useCreatePdf';
 import { downloadFile } from '../utils';
 
 interface PrintToPDFButtonProps {
@@ -21,12 +21,12 @@ const PrintToPDFButton = ({ pad }: PrintToPDFButtonProps) => {
   const { toast } = useToastProvider();
   const { padsStore } = usePadStore();
   const {
-    mutate: createPdfFromMarkdown,
+    mutate: createPdf,
     data: pdf,
     isSuccess,
     isPending,
     error,
-  } = useCreatePdfFromMarkdown();
+  } = useCreatePdf();
 
   useEffect(() => {
     setIsFetching(isPending);
@@ -61,11 +61,12 @@ const PrintToPDFButton = ({ pad }: PrintToPDFButtonProps) => {
       return;
     }
 
-    const markdown = await editor.blocksToMarkdownLossy(editor.document);
+    const body = await editor.blocksToHTMLLossy(editor.document);
 
-    createPdfFromMarkdown({
+    createPdf({
       templateId: '472d0633-20b8-4cb1-998a-1134ade092ba',
-      markdown,
+      body,
+      body_type: 'markdown',
     });
   }
 


### PR DESCRIPTION
## Purpose

The endpoint `templates/[ID]/generate-document` was converting from markdown to html, but the frontend can provide the body directly in html format, so we can avoid the conversion, it will reduce the amount of data lost.

Solution:
Add body type on generate-document endpoint
to allow to choose between markdown and html.


## Proposal

Description...

- [x] Add `body_type` param on `templates/[ID]/generate-document` endpoint
- [x] Adapt frontend to not convert to markdown anymore
- [x] Test
