### PR TITLE
✨(app-impress) button editor convert from markdown

### DIFF
--- a/src/frontend/apps/e2e/__tests__/app-impress/header.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/header.spec.ts
@@ -27,10 +27,6 @@ test.describe('Header', () => {
       /Marianne/i,
     );
 
-    await expect(
-      header.getByText('Les applications de La Suite numérique'),
-    ).toBeVisible();
-
     await expect(header.getByAltText('Language Icon')).toBeVisible();
 
     await expect(header.getByText('John Doe')).toBeVisible();

--- a/src/frontend/apps/e2e/__tests__/app-impress/pad-editor.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/pad-editor.spec.ts
@@ -77,4 +77,34 @@ test.describe('Pad Editor', () => {
     expect(pdfText).toContain('La directrice'); // This is the template text
     expect(pdfText).toContain('Hello World'); // This is the pad text
   });
+
+  test('markdown button converts from markdown to the editor syntax json', async ({
+    page,
+    browserName,
+  }) => {
+    const randomPad = await createPad(page, 'pad-markdown', browserName, 1);
+
+    await expect(page.locator('h2').getByText(randomPad[0])).toBeVisible();
+
+    await page.locator('.ProseMirror.bn-editor').click();
+    await page
+      .locator('.ProseMirror.bn-editor')
+      .fill('[test markdown](http://test-markdown.html)');
+
+    await expect(page.getByText('[test markdown]')).toBeVisible();
+
+    await page.getByText('[test markdown]').dblclick();
+    await page
+      .getByRole('button', {
+        name: 'M',
+      })
+      .click();
+
+    await expect(page.getByText('[test markdown]')).toBeHidden();
+    await expect(
+      page.getByRole('link', {
+        name: 'test markdown',
+      }),
+    ).toHaveAttribute('href', 'http://test-markdown.html');
+  });
 });

--- a/src/frontend/apps/impress/src/features/header/Header.tsx
+++ b/src/frontend/apps/impress/src/features/header/Header.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { Box, Text } from '@/components/';
-import { ApplicationsMenu } from '@/features/header/ApplicationsMenu';
 
 import { LanguagePicker } from '../language/';
 
@@ -89,7 +88,6 @@ export const Header = () => {
                 alt={t(`Profile picture`)}
               />
             </Box>
-            <ApplicationsMenu />
           </Box>
         </Box>
       </Box>

--- a/src/frontend/apps/impress/src/features/pads/pad/components/BlockNoteEditor.tsx
+++ b/src/frontend/apps/impress/src/features/pads/pad/components/BlockNoteEditor.tsx
@@ -10,6 +10,8 @@ import { usePadStore } from '../stores';
 import { Pad } from '../types';
 import { randomColor } from '../utils';
 
+import { BlockNoteToolbar } from './BlockNoteToolbar';
+
 interface BlockNoteEditorProps {
   pad: Pad;
 }
@@ -67,7 +69,9 @@ export const BlockNoteContent = ({ pad, provider }: BlockNoteContentProps) => {
         };
       `}
     >
-      <BlockNoteView editor={editor} />
+      <BlockNoteView editor={editor} formattingToolbar={false}>
+        <BlockNoteToolbar />
+      </BlockNoteView>
     </Box>
   );
 };

--- a/src/frontend/apps/impress/src/features/pads/pad/components/BlockNoteToolbar.tsx
+++ b/src/frontend/apps/impress/src/features/pads/pad/components/BlockNoteToolbar.tsx
@@ -1,0 +1,129 @@
+import {
+  BasicTextStyleButton,
+  BlockTypeSelect,
+  ColorStyleButton,
+  CreateLinkButton,
+  FormattingToolbar,
+  FormattingToolbarController,
+  ImageCaptionButton,
+  NestBlockButton,
+  ReplaceImageButton,
+  TextAlignButton,
+  ToolbarButton,
+  UnnestBlockButton,
+  useBlockNoteEditor,
+} from '@blocknote/react';
+import '@blocknote/react/style.css';
+import { forEach, isArray } from 'lodash';
+import React from 'react';
+
+export const BlockNoteToolbar = () => {
+  return (
+    <FormattingToolbarController
+      formattingToolbar={() => (
+        <FormattingToolbar>
+          <BlockTypeSelect key="blockTypeSelect" />
+
+          {/* Extra button to convert from markdown to json */}
+          <MarkdownButton key="customButton" />
+
+          <ImageCaptionButton key="imageCaptionButton" />
+          <ReplaceImageButton key="replaceImageButton" />
+
+          <BasicTextStyleButton basicTextStyle="bold" key="boldStyleButton" />
+          <BasicTextStyleButton
+            basicTextStyle="italic"
+            key="italicStyleButton"
+          />
+          <BasicTextStyleButton
+            basicTextStyle="underline"
+            key="underlineStyleButton"
+          />
+          <BasicTextStyleButton
+            basicTextStyle="strike"
+            key="strikeStyleButton"
+          />
+          {/* Extra button to toggle code styles */}
+          <BasicTextStyleButton key="codeStyleButton" basicTextStyle="code" />
+
+          <TextAlignButton textAlignment="left" key="textAlignLeftButton" />
+          <TextAlignButton textAlignment="center" key="textAlignCenterButton" />
+          <TextAlignButton textAlignment="right" key="textAlignRightButton" />
+
+          <ColorStyleButton key="colorStyleButton" />
+
+          <NestBlockButton key="nestBlockButton" />
+          <UnnestBlockButton key="unnestBlockButton" />
+
+          <CreateLinkButton key="createLinkButton" />
+        </FormattingToolbar>
+      )}
+    />
+  );
+};
+
+type Block = {
+  type: string;
+  text: string;
+  content: Block[];
+};
+
+function isBlock(block: Block): block is Block {
+  return (
+    block.content &&
+    isArray(block.content) &&
+    block.content.length > 0 &&
+    typeof block.type !== 'undefined'
+  );
+}
+
+const recursiveContent = (content: Block[], base: string = '') => {
+  let fullContent = base;
+  for (const innerContent of content) {
+    if (innerContent.type === 'text') {
+      fullContent += innerContent.text;
+    } else if (isBlock(innerContent)) {
+      fullContent = recursiveContent(innerContent.content, fullContent);
+    }
+  }
+
+  return fullContent;
+};
+
+/**
+ * Custom Formatting Toolbar Button to convert markdown to json.
+ */
+export function MarkdownButton() {
+  const editor = useBlockNoteEditor();
+
+  const handleConvertMarkdown = () => {
+    const blocks = editor.getSelection()?.blocks;
+
+    forEach(blocks, async (block) => {
+      if (!isBlock(block as unknown as Block)) {
+        return;
+      }
+
+      try {
+        const fullContent = recursiveContent(
+          block.content as unknown as Block[],
+        );
+
+        const blockMarkdown =
+          await editor.tryParseMarkdownToBlocks(fullContent);
+        editor.replaceBlocks([block.id], blockMarkdown);
+      } catch (error) {
+        console.error('Error parsing Markdown:', error);
+      }
+    });
+  };
+
+  return (
+    <ToolbarButton
+      mainTooltip="Convert Markdown"
+      onClick={handleConvertMarkdown}
+    >
+      M
+    </ToolbarButton>
+  );
+}

--- a/src/frontend/apps/impress/src/pages/_document.tsx
+++ b/src/frontend/apps/impress/src/pages/_document.tsx
@@ -11,12 +11,7 @@ import '@/i18n/initI18n';
 export default function RootLayout() {
   return (
     <Html lang="en">
-      <Head>
-        <link
-          rel="stylesheet"
-          href="https://suite-numerique-gaufre.osc-fr1.scalingo.io/public/styles/gaufre-vanilla.css"
-        />
-      </Head>
+      <Head />
       <body suppressHydrationWarning={process.env.NODE_ENV === 'development'}>
         <Main />
         <NextScript />


### PR DESCRIPTION
## Purpose

Some people prefer to write in markdown, or had already written stuff in markdown, so this commit adds a button to the editor that will convert the markdown to the editor's format.

## Proposal

- [x] add button to convert from markdown to editor's format
- [x] tests

## Demo

[scrnli_4_16_2024_1-07-13 PM.webm](https://github.com/numerique-gouv/impress/assets/25994652/022be9fc-86f3-418c-a439-0d5ba7818d71)
