### PR TITLE
✨create resource with is_public param

### DIFF
--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -136,7 +136,7 @@ class DocumentSerializer(BaseResourceSerializer):
 
     class Meta:
         model = models.Document
-        fields = ["id", "title", "accesses", "abilities"]
+        fields = ["id", "title", "accesses", "abilities", "is_public"]
         read_only_fields = ["id", "accesses", "abilities"]
 
 
@@ -145,7 +145,16 @@ class TemplateSerializer(BaseResourceSerializer):
 
     class Meta:
         model = models.Template
-        fields = ["id", "title", "code_editor", "accesses", "abilities", "css", "code"]
+        fields = [
+            "id",
+            "title",
+            "code_editor",
+            "accesses",
+            "abilities",
+            "css",
+            "code",
+            "is_public",
+        ]
         read_only_fields = ["id", "accesses", "abilities"]
 
     def to_representation(self, instance):

--- a/src/backend/core/tests/documents/test_api_documents_retrieve.py
+++ b/src/backend/core/tests/documents/test_api_documents_retrieve.py
@@ -27,6 +27,7 @@ def test_api_documents_retrieve_anonymous_public():
         },
         "accesses": [],
         "title": document.title,
+        "is_public": True,
     }
 
 
@@ -67,6 +68,7 @@ def test_api_documents_retrieve_authenticated_unrelated_public():
         },
         "accesses": [],
         "title": document.title,
+        "is_public": True,
     }
 
 
@@ -131,6 +133,7 @@ def test_api_documents_retrieve_authenticated_related_direct():
         "id": str(document.id),
         "title": document.title,
         "abilities": document.get_abilities(user),
+        'is_public': document.is_public,
     }
 
 
@@ -244,6 +247,7 @@ def test_api_documents_retrieve_authenticated_related_team_members(
         "id": str(document.id),
         "title": document.title,
         "abilities": document.get_abilities(user),
+        'is_public': False,
     }
 
 
@@ -340,6 +344,7 @@ def test_api_documents_retrieve_authenticated_related_team_administrators(
         "id": str(document.id),
         "title": document.title,
         "abilities": document.get_abilities(user),
+        'is_public': False,
     }
 
 
@@ -440,4 +445,5 @@ def test_api_documents_retrieve_authenticated_related_team_owners(
         "id": str(document.id),
         "title": document.title,
         "abilities": document.get_abilities(user),
+        'is_public': False,
     }

--- a/src/backend/core/tests/templates/test_api_templates_retrieve.py
+++ b/src/backend/core/tests/templates/test_api_templates_retrieve.py
@@ -29,6 +29,7 @@ def test_api_templates_retrieve_anonymous_public():
         "accesses": [],
         "title": template.title,
         "code_editor": {},
+        "is_public": True,
     }
 
 
@@ -71,6 +72,7 @@ def test_api_templates_retrieve_authenticated_unrelated_public():
         "accesses": [],
         "title": template.title,
         "code_editor": {},
+        "is_public": True,
     }
 
 
@@ -136,6 +138,7 @@ def test_api_templates_retrieve_authenticated_related_direct():
         "title": template.title,
         "abilities": template.get_abilities(user),
         "code_editor": {},
+        "is_public": template.is_public,
     }
 
 
@@ -250,6 +253,7 @@ def test_api_templates_retrieve_authenticated_related_team_members(
         "title": template.title,
         "abilities": template.get_abilities(user),
         "code_editor": {},
+        "is_public": False,
     }
 
 
@@ -346,6 +350,7 @@ def test_api_templates_retrieve_authenticated_related_team_administrators(
         "title": template.title,
         "abilities": template.get_abilities(user),
         "code_editor": {},
+        "is_public": False,
     }
 
 
@@ -446,4 +451,5 @@ def test_api_templates_retrieve_authenticated_related_team_owners(
         "title": template.title,
         "abilities": template.get_abilities(user),
         "code_editor": {},
+        "is_public": False,
     }

--- a/src/frontend/apps/impress/cunningham.ts
+++ b/src/frontend/apps/impress/cunningham.ts
@@ -361,6 +361,7 @@ const config = {
         'forms-switch': {
           'handle-border-radius': '2px',
           'rail-border-radius': '4px',
+          'accent-color': 'var(--c--theme--colors--primary-text)',
         },
         'forms-textarea': {
           'border-radius': '0',

--- a/src/frontend/apps/impress/src/cunningham/cunningham-tokens.css
+++ b/src/frontend/apps/impress/src/cunningham/cunningham-tokens.css
@@ -486,6 +486,9 @@
   );
   --c--components--forms-switch--handle-border-radius: 2px;
   --c--components--forms-switch--rail-border-radius: 4px;
+  --c--components--forms-switch--accent-color: var(
+    --c--theme--colors--primary-text
+  );
   --c--components--forms-textarea--border-radius: 0;
 }
 

--- a/src/frontend/apps/impress/src/cunningham/cunningham-tokens.ts
+++ b/src/frontend/apps/impress/src/cunningham/cunningham-tokens.ts
@@ -487,6 +487,7 @@ export const tokens = {
         'forms-switch': {
           'handle-border-radius': '2px',
           'rail-border-radius': '4px',
+          'accent-color': 'var(--c--theme--colors--primary-text)',
         },
         'forms-textarea': { 'border-radius': '0' },
       },

--- a/src/frontend/apps/impress/src/features/pads/pads-create/api/useCreatePad.tsx
+++ b/src/frontend/apps/impress/src/features/pads/pads-create/api/useCreatePad.tsx
@@ -1,18 +1,22 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { APIError, errorCauses, fetchAPI } from '@/api';
-import { KEY_LIST_PAD } from '@/features/pads';
+import { KEY_LIST_PAD, Pad } from '@/features/pads';
 
-type CreatePadResponse = {
-  id: string;
+type CreatePadParam = {
   title: string;
+  is_public: boolean;
 };
 
-export const createPad = async (title: string): Promise<CreatePadResponse> => {
+export const createPad = async ({
+  title,
+  is_public,
+}: CreatePadParam): Promise<Pad> => {
   const response = await fetchAPI(`documents/`, {
     method: 'POST',
     body: JSON.stringify({
       title,
+      is_public,
     }),
   });
 
@@ -20,16 +24,16 @@ export const createPad = async (title: string): Promise<CreatePadResponse> => {
     throw new APIError('Failed to create the pad', await errorCauses(response));
   }
 
-  return response.json() as Promise<CreatePadResponse>;
+  return response.json() as Promise<Pad>;
 };
 
 interface CreatePadProps {
-  onSuccess: (data: CreatePadResponse) => void;
+  onSuccess: (data: Pad) => void;
 }
 
 export function useCreatePad({ onSuccess }: CreatePadProps) {
   const queryClient = useQueryClient();
-  return useMutation<CreatePadResponse, APIError, string>({
+  return useMutation<Pad, APIError, CreatePadParam>({
     mutationFn: createPad,
     onSuccess: (data) => {
       void queryClient.invalidateQueries({

--- a/src/frontend/apps/impress/src/features/pads/pads-create/components/CardCreatePad.tsx
+++ b/src/frontend/apps/impress/src/features/pads/pads-create/components/CardCreatePad.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@openfun/cunningham-react';
+import { Button, Switch } from '@openfun/cunningham-react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -52,12 +52,16 @@ export const CardCreatePad = () => {
           label={t('Pad name')}
           {...{ error, isError, isPending, setPadName }}
         />
+        <Switch label={t('Is it public ?')} labelSide="right" />
       </Box>
       <Box $justify="space-between" $direction="row" $align="center">
         <StyledLink href="/">
           <Button color="secondary">{t('Cancel')}</Button>
         </StyledLink>
-        <Button onClick={() => createPad(padName)} disabled={!padName}>
+        <Button
+          onClick={() => createPad({ title: padName, is_public: true })}
+          disabled={!padName}
+        >
           {t('Create the pad')}
         </Button>
       </Box>

--- a/src/frontend/apps/impress/src/features/templates/template-create/api/useCreateTemplate.tsx
+++ b/src/frontend/apps/impress/src/features/templates/template-create/api/useCreateTemplate.tsx
@@ -1,20 +1,22 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { APIError, errorCauses, fetchAPI } from '@/api';
-import { KEY_LIST_TEMPLATE } from '@/features/templates';
+import { KEY_LIST_TEMPLATE, Template } from '@/features/templates';
 
-type CreateTemplateResponse = {
-  id: string;
+type CreateTemplateParam = {
   title: string;
+  is_public: boolean;
 };
 
-export const createTemplate = async (
-  title: string,
-): Promise<CreateTemplateResponse> => {
+export const createTemplate = async ({
+  title,
+  is_public,
+}: CreateTemplateParam): Promise<Template> => {
   const response = await fetchAPI(`templates/`, {
     method: 'POST',
     body: JSON.stringify({
       title,
+      is_public,
     }),
   });
 
@@ -25,16 +27,16 @@ export const createTemplate = async (
     );
   }
 
-  return response.json() as Promise<CreateTemplateResponse>;
+  return response.json() as Promise<Template>;
 };
 
 interface CreateTemplateProps {
-  onSuccess: (data: CreateTemplateResponse) => void;
+  onSuccess: (data: Template) => void;
 }
 
 export function useCreateTemplate({ onSuccess }: CreateTemplateProps) {
   const queryClient = useQueryClient();
-  return useMutation<CreateTemplateResponse, APIError, string>({
+  return useMutation<Template, APIError, CreateTemplateParam>({
     mutationFn: createTemplate,
     onSuccess: (data) => {
       void queryClient.invalidateQueries({

--- a/src/frontend/apps/impress/src/features/templates/template-create/components/CardCreateTemplate.tsx
+++ b/src/frontend/apps/impress/src/features/templates/template-create/components/CardCreateTemplate.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@openfun/cunningham-react';
+import { Button, Switch } from '@openfun/cunningham-react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -52,13 +52,16 @@ export const CardCreateTemplate = () => {
           label={t('Template name')}
           {...{ error, isError, isPending, setTemplateName }}
         />
+        <Switch label={t('Is it public ?')} labelSide="right" />
       </Box>
       <Box $justify="space-between" $direction="row" $align="center">
         <StyledLink href="/">
           <Button color="secondary">{t('Cancel')}</Button>
         </StyledLink>
         <Button
-          onClick={() => createTemplate(templateName)}
+          onClick={() =>
+            createTemplate({ title: templateName, is_public: true })
+          }
           disabled={!templateName}
         >
           {t('Create the template')}


### PR DESCRIPTION
## Purpose

To share easily some template or document we can set them to `is_public` during the creation.

## Proposal

- [x] add a switch `is_public` on the creation resource (template / pad)
- [x] update backend serializers

## Demo
![image](https://github.com/numerique-gouv/impress/assets/25994652/1e9c5f43-5a86-4b1a-a335-da28d817c5b4)

