### PR TITLE
🐛(frontend) fix all the resources were public

### DIFF
--- a/src/frontend/apps/e2e/__tests__/app-impress/pad-create.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/pad-create.spec.ts
@@ -28,6 +28,8 @@ test.describe('Pad Create', () => {
       }),
     ).toBeVisible();
 
+    await expect(card.getByText('Is it public ?')).toBeVisible();
+
     await expect(
       card.getByRole('button', {
         name: 'Create the pad',
@@ -104,5 +106,25 @@ test.describe('Pad Create', () => {
     ).toBeVisible({
       timeout: 15000,
     });
+  });
+
+  test('checks that the pad is public', async ({ page, browserName }) => {
+    const responsePromisePad = page.waitForResponse(
+      (response) =>
+        response.url().includes('/documents/') && response.status() === 201,
+    );
+
+    const panel = page.getByLabel('Pads panel').first();
+
+    await panel.getByRole('button', { name: 'Add a pad' }).click();
+
+    const padName = `My routing pad ${browserName}-${Math.floor(Math.random() * 1000)}`;
+    await page.getByText('Pad name').fill(padName);
+    await page.getByText('Is it public ?').click();
+    await page.getByRole('button', { name: 'Create the pad' }).click();
+
+    const responsePad = await responsePromisePad;
+    const is_public = (await responsePad.json()).is_public;
+    expect(is_public).toBeTruthy();
   });
 });

--- a/src/frontend/apps/impress/src/features/pads/pad/components/BlockNoteEditor.tsx
+++ b/src/frontend/apps/impress/src/features/pads/pad/components/BlockNoteEditor.tsx
@@ -1,5 +1,6 @@
 import { BlockNoteView, useCreateBlockNote } from '@blocknote/react';
 import '@blocknote/react/style.css';
+import { Alert, VariantType } from '@openfun/cunningham-react';
 import React, { useEffect, useState } from 'react';
 import { WebrtcProvider } from 'y-webrtc';
 
@@ -57,6 +58,8 @@ export const BlockNoteContent = ({ pad, provider }: BlockNoteContentProps) => {
     },
   });
 
+  editor.isEditable = pad.abilities.partial_update;
+
   useEffect(() => {
     setEditor(pad.id, editor);
   }, [setEditor, pad.id, editor]);
@@ -69,6 +72,13 @@ export const BlockNoteContent = ({ pad, provider }: BlockNoteContentProps) => {
         };
       `}
     >
+      {!pad.abilities.partial_update && (
+        <Box className="m-b" $css="margin-top:0;">
+          <Alert
+            type={VariantType.WARNING}
+          >{`Read only, you don't have the right to update this pad.`}</Alert>
+        </Box>
+      )}
       <BlockNoteView editor={editor} formattingToolbar={false}>
         <BlockNoteToolbar />
       </BlockNoteView>

--- a/src/frontend/apps/impress/src/features/pads/pad/types.tsx
+++ b/src/frontend/apps/impress/src/features/pads/pad/types.tsx
@@ -28,5 +28,6 @@ export interface Pad {
     retrieve: boolean;
     manage_accesses: boolean;
     update: boolean;
+    partial_update: boolean;
   };
 }

--- a/src/frontend/apps/impress/src/features/pads/pads-create/components/CardCreatePad.tsx
+++ b/src/frontend/apps/impress/src/features/pads/pads-create/components/CardCreatePad.tsx
@@ -25,6 +25,7 @@ export const CardCreatePad = () => {
     },
   });
   const [padName, setPadName] = useState('');
+  const [padPublic, setPadPublic] = useState(false);
   const { colorsTokens } = useCunninghamTheme();
 
   return (
@@ -52,14 +53,18 @@ export const CardCreatePad = () => {
           label={t('Pad name')}
           {...{ error, isError, isPending, setPadName }}
         />
-        <Switch label={t('Is it public ?')} labelSide="right" />
+        <Switch
+          label={t('Is it public ?')}
+          labelSide="right"
+          onChange={() => setPadPublic(!padPublic)}
+        />
       </Box>
       <Box $justify="space-between" $direction="row" $align="center">
         <StyledLink href="/">
           <Button color="secondary">{t('Cancel')}</Button>
         </StyledLink>
         <Button
-          onClick={() => createPad({ title: padName, is_public: true })}
+          onClick={() => createPad({ title: padName, is_public: padPublic })}
           disabled={!padName}
         >
           {t('Create the pad')}

--- a/src/frontend/apps/impress/src/features/templates/template-create/components/CardCreateTemplate.tsx
+++ b/src/frontend/apps/impress/src/features/templates/template-create/components/CardCreateTemplate.tsx
@@ -25,6 +25,7 @@ export const CardCreateTemplate = () => {
     },
   });
   const [templateName, setTemplateName] = useState('');
+  const [templatePublic, setTemplatePublic] = useState(false);
   const { colorsTokens } = useCunninghamTheme();
 
   return (
@@ -52,7 +53,11 @@ export const CardCreateTemplate = () => {
           label={t('Template name')}
           {...{ error, isError, isPending, setTemplateName }}
         />
-        <Switch label={t('Is it public ?')} labelSide="right" />
+        <Switch
+          label={t('Is it public ?')}
+          labelSide="right"
+          onChange={() => setTemplatePublic(!templatePublic)}
+        />
       </Box>
       <Box $justify="space-between" $direction="row" $align="center">
         <StyledLink href="/">
@@ -60,7 +65,7 @@ export const CardCreateTemplate = () => {
         </StyledLink>
         <Button
           onClick={() =>
-            createTemplate({ title: templateName, is_public: true })
+            createTemplate({ title: templateName, is_public: templatePublic })
           }
           disabled={!templateName}
         >

--- a/src/frontend/apps/impress/src/features/templates/template/components/TemplateEditor.tsx
+++ b/src/frontend/apps/impress/src/features/templates/template/components/TemplateEditor.tsx
@@ -52,7 +52,7 @@ export const TemplateEditor = ({ template }: TemplateEditorProps) => {
       ? template.code_editor
       : editor.getProjectData();
 
-    editor.loadProjectData(projectData);
+    editor?.loadProjectData(projectData);
 
     editor.Storage.add('remote', {
       load() {
@@ -115,6 +115,14 @@ export const TemplateEditor = ({ template }: TemplateEditorProps) => {
           <Alert
             type={VariantType.WARNING}
           >{`The {{body}} tag is necessary to works with the pads.`}</Alert>
+        </Box>
+      )}
+
+      {!template.abilities.partial_update && (
+        <Box className="m-b" $css="margin-top:0;">
+          <Alert
+            type={VariantType.WARNING}
+          >{`Read only, you don't have the right to update this template.`}</Alert>
         </Box>
       )}
 

--- a/src/frontend/apps/impress/src/features/templates/template/types.tsx
+++ b/src/frontend/apps/impress/src/features/templates/template/types.tsx
@@ -27,6 +27,7 @@ export interface Template {
     manage_accesses: boolean;
     retrieve: boolean;
     update: boolean;
+    partial_update: boolean;
   };
   accesses: Access[];
   code_editor: ProjectData;

--- a/src/frontend/packages/eslint-config-impress/playwright.js
+++ b/src/frontend/packages/eslint-config-impress/playwright.js
@@ -27,6 +27,7 @@ module.exports = {
       plugins: ['playwright'],
       rules: {
         '@typescript-eslint/no-unsafe-member-access': 'off',
+        '@typescript-eslint/no-unsafe-assignment': 'off',
       },
     },
   ],


### PR DESCRIPTION
## Purpose

All the resources were public, we fixed that.

When a resource is public, the users can see it but not edit it. 
This PR adds a warning message to the user to tell them that the resource is not editable.

## Proposal

- [x] update correctly depend the user's choice
- [x] add warning message when not editable
- [x] test

## Demo
![scrnli_4_18_2024_1-35-32 PM](https://github.com/numerique-gouv/impress/assets/25994652/d9843d44-12bb-4e7c-b334-b5d2b185b0af)
