### PR TITLE
💚(CI) increase timeout e2e job

### DIFF
--- a/.github/workflows/impress-frontend.yml
+++ b/.github/workflows/impress-frontend.yml
@@ -101,7 +101,7 @@ jobs:
   test-e2e:
     runs-on: ubuntu-latest
     needs: build-front
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Purpose

It can happen that the e2e job takes longer than 10 minutes to finish, we increase the timeout to 15 minutes to avoid the job to fail.
