### PR TITLE
✨(frontend) persistance-documents

### DIFF
--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -7,8 +7,6 @@ from timezone_field.rest_framework import TimeZoneSerializerField
 
 from core import models
 
-from .fields import JSONField
-
 
 class UserSerializer(serializers.ModelSerializer):
     """Serialize users."""
@@ -136,7 +134,7 @@ class BaseResourceSerializer(serializers.ModelSerializer):
 class DocumentSerializer(BaseResourceSerializer):
     """Serialize documents."""
 
-    content = JSONField(required=False)
+    content = serializers.CharField(required=False)
 
     class Meta:
         model = models.Document

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -344,7 +344,7 @@ class DocumentViewSet(
 
         return drf_response.Response(
             {
-                "content": json.loads(response["Body"].read()),
+                "content": response["Body"].read().decode("utf-8"),
                 "last_modified": response["LastModified"],
             }
         )

--- a/src/backend/core/factories.py
+++ b/src/backend/core/factories.py
@@ -35,7 +35,7 @@ class DocumentFactory(factory.django.DjangoModelFactory):
 
     title = factory.Sequence(lambda n: f"document{n}")
     is_public = factory.Faker("boolean")
-    content = factory.LazyFunction(lambda: {"foo": fake.word()})
+    content = factory.Sequence(lambda n: f"content{n}")
 
     @factory.post_generation
     def users(self, create, extracted, **kwargs):

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -325,16 +325,15 @@ class Document(BaseModel):
             except (FileNotFoundError, ClientError):
                 pass
             else:
-                self._content = json.loads(response["Body"].read())
+                self._content = response["Body"].read().decode('utf-8')
         return self._content
 
     @content.setter
     def content(self, content):
         """Cache the content, don't write to object storage yet"""
-        if isinstance(content, str):
-            content = json.loads(content)
-        if not isinstance(content, dict):
-            raise ValueError("content should be a json object.")
+        if not isinstance(content, str):
+            raise ValueError("content should be a string.")
+        
         self._content = content
 
     def get_content_response(self, version_id=""):
@@ -349,7 +348,7 @@ class Document(BaseModel):
 
         if self._content:
             file_key = self.file_key
-            bytes_content = json.dumps(self._content).encode("utf-8")
+            bytes_content = self._content.encode("utf-8")
 
             if default_storage.exists(file_key):
                 response = default_storage.connection.meta.client.head_object(

--- a/src/backend/core/tests/documents/test_api_documents_retrieve.py
+++ b/src/backend/core/tests/documents/test_api_documents_retrieve.py
@@ -31,7 +31,7 @@ def test_api_documents_retrieve_anonymous_public():
         "accesses": [],
         "title": document.title,
         "is_public": True,
-        "content": {"foo": document.content["foo"]},
+        "content": document.content,
     }
 
 
@@ -76,7 +76,7 @@ def test_api_documents_retrieve_authenticated_unrelated_public():
         "accesses": [],
         "title": document.title,
         "is_public": True,
-        "content": {"foo": document.content["foo"]},
+        "content": document.content,
     }
 
 
@@ -140,7 +140,7 @@ def test_api_documents_retrieve_authenticated_related_direct():
     assert response.json() == {
         "id": str(document.id),
         "title": document.title,
-        "content": {"foo": document.content["foo"]},
+        "content": document.content,
         "abilities": document.get_abilities(user),
         "is_public": document.is_public,
     }
@@ -255,7 +255,7 @@ def test_api_documents_retrieve_authenticated_related_team_members(
     assert response.json() == {
         "id": str(document.id),
         "title": document.title,
-        "content": {"foo": document.content["foo"]},
+        "content": document.content,
         "abilities": document.get_abilities(user),
         "is_public": False,
     }
@@ -353,7 +353,7 @@ def test_api_documents_retrieve_authenticated_related_team_administrators(
     assert response.json() == {
         "id": str(document.id),
         "title": document.title,
-        "content": {"foo": document.content["foo"]},
+        "content": document.content,
         "abilities": document.get_abilities(user),
         "is_public": False,
     }
@@ -455,7 +455,7 @@ def test_api_documents_retrieve_authenticated_related_team_owners(
     assert response.json() == {
         "id": str(document.id),
         "title": document.title,
-        "content": {"foo": document.content["foo"]},
+        "content": document.content,
         "abilities": document.get_abilities(user),
         "is_public": False,
     }

--- a/src/backend/core/tests/test_api_document_versions.py
+++ b/src/backend/core/tests/test_api_document_versions.py
@@ -128,7 +128,7 @@ def test_api_document_versions_list_authenticated_related(via, mock_user_get_tea
     assert len(content["versions"]) == 0
 
     # Add a new version to the document
-    document.content = {"foo": "bar"}
+    document.content = "new content"
     document.save()
 
     response = client.get(
@@ -243,7 +243,7 @@ def test_api_document_versions_retrieve_authenticated_related(via, mock_user_get
 
     # Create a new version should make it available to the user
     time.sleep(1)  # minio stores datetimes with the precision of a second
-    document.content = {"foo": "bar"}
+    document.content = "new content"
     document.save()
 
     version_id = document.get_versions_slice()["versions"][0]["version_id"]
@@ -253,7 +253,7 @@ def test_api_document_versions_retrieve_authenticated_related(via, mock_user_get
     )
 
     assert response.status_code == 200
-    assert response.json()["content"] == {"foo": "bar"}
+    assert response.json()["content"] == "new content"
 
 
 def test_api_document_versions_create_anonymous():
@@ -459,7 +459,7 @@ def test_api_document_versions_delete_member(via, mock_user_get_teams):
 
     # Create a new version should make it available to the user
     time.sleep(1)  # minio stores datetimes with the precision of a second
-    document.content = {"foo": "bar"}
+    document.content = "new content"
     document.save()
 
     versions = document.get_versions_slice()["versions"]
@@ -503,7 +503,7 @@ def test_api_document_versions_delete_administrator_or_owner(via, mock_user_get_
 
     # Create a new version should make it available to the user
     time.sleep(1)  # minio stores datetimes with the precision of a second
-    document.content = {"foo": "bar"}
+    document.content = "new content"
     document.save()
 
     versions = document.get_versions_slice()["versions"]

--- a/src/backend/core/tests/test_models_documents.py
+++ b/src/backend/core/tests/test_models_documents.py
@@ -196,7 +196,7 @@ def test_models_documents_get_versions_slice(settings):
     # Create a document with 7 versions
     document = factories.DocumentFactory()
     for i in range(6):
-        document.content = {"foo": f"bar{i:d}"}
+        document.content = f"bar{i:d}"
         document.save()
 
     # Add a version not related to the first document
@@ -246,7 +246,7 @@ def test_models_documents_version_duplicate():
     assert len(response["Versions"]) == 1
 
     # Save modified content
-    document.content = {"foo": "spam"}
+    document.content = "new content"
     document.save()
 
     response = default_storage.connection.meta.client.list_object_versions(

--- a/src/frontend/apps/e2e/__tests__/app-impress/pad-editor.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/pad-editor.spec.ts
@@ -138,4 +138,63 @@ test.describe('Pad Editor', () => {
     await expect(page.getByText('Hello World Pad 2')).toBeHidden();
     await expect(page.getByText('Hello World Pad 1')).toBeVisible();
   });
+
+  test('it saves the doc when we change pages', async ({
+    page,
+    browserName,
+  }) => {
+    const [pad] = await createPad(page, 'pad-save-page', browserName, 1);
+
+    const panel = page.getByLabel('Pads panel').first();
+
+    // Check the first pad
+    await panel.getByText(pad).click();
+    await expect(page.locator('h2').getByText(pad)).toBeVisible();
+    await page.locator('.ProseMirror.bn-editor').click();
+    await page
+      .locator('.ProseMirror.bn-editor')
+      .fill('Hello World Pad persisted 1');
+    await expect(page.getByText('Hello World Pad persisted 1')).toBeVisible();
+
+    await panel
+      .getByRole('button', {
+        name: 'Add a pad',
+      })
+      .click();
+
+    const card = page.getByLabel('Create new pad card').first();
+    await expect(
+      card.getByRole('heading', {
+        name: 'Name the pad',
+        level: 3,
+      }),
+    ).toBeVisible();
+
+    await page.goto('/');
+
+    await panel.getByText(pad).click();
+
+    await expect(page.getByText('Hello World Pad persisted 1')).toBeVisible();
+  });
+
+  test('it saves the doc when we quit pages', async ({ page, browserName }) => {
+    const [pad] = await createPad(page, 'pad-save-quit', browserName, 1);
+
+    const panel = page.getByLabel('Pads panel').first();
+
+    // Check the first pad
+    await panel.getByText(pad).click();
+    await expect(page.locator('h2').getByText(pad)).toBeVisible();
+    await page.locator('.ProseMirror.bn-editor').click();
+    await page
+      .locator('.ProseMirror.bn-editor')
+      .fill('Hello World Pad persisted 2');
+    await expect(page.getByText('Hello World Pad persisted 2')).toBeVisible();
+
+    await page.goto('/');
+
+    await panel.getByText(pad).click();
+
+    await expect(page.getByText('Hello World Pad persisted 2')).toBeVisible();
+  });
 });

--- a/src/frontend/apps/impress/src/features/pads/pad/api/useUpdatePad.tsx
+++ b/src/frontend/apps/impress/src/features/pads/pad/api/useUpdatePad.tsx
@@ -1,0 +1,45 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { APIError, errorCauses, fetchAPI } from '@/api';
+import { Pad } from '@/features/pads';
+
+export type PadParams = Pick<Pad, 'id'> &
+  Partial<Pick<Pad, 'content' | 'title' | 'is_public'>>;
+
+export const updatePad = async ({ id, ...params }: PadParams): Promise<Pad> => {
+  const response = await fetchAPI(`documents/${id}/`, {
+    method: 'PATCH',
+    body: JSON.stringify({
+      ...params,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new APIError('Failed to update the pad', await errorCauses(response));
+  }
+
+  return response.json() as Promise<Pad>;
+};
+
+interface UpdatePadProps {
+  onSuccess?: (data: Pad) => void;
+  listInvalideQueries?: string[];
+}
+
+export function useUpdatePad({
+  onSuccess,
+  listInvalideQueries,
+}: UpdatePadProps = {}) {
+  const queryClient = useQueryClient();
+  return useMutation<Pad, APIError, PadParams>({
+    mutationFn: updatePad,
+    onSuccess: (data) => {
+      listInvalideQueries?.forEach((queryKey) => {
+        void queryClient.invalidateQueries({
+          queryKey: [queryKey],
+        });
+      });
+      onSuccess?.(data);
+    },
+  });
+}

--- a/src/frontend/apps/impress/src/features/pads/pad/components/BlockNoteEditor.tsx
+++ b/src/frontend/apps/impress/src/features/pads/pad/components/BlockNoteEditor.tsx
@@ -7,6 +7,7 @@ import { WebrtcProvider } from 'y-webrtc';
 import { Box } from '@/components';
 import { useAuthStore } from '@/core/auth';
 
+import useSavePad from '../hook/useSavePad';
 import { usePadStore } from '../stores';
 import { Pad } from '../types';
 import { randomColor } from '../utils';
@@ -37,6 +38,7 @@ interface BlockNoteContentProps {
 export const BlockNoteContent = ({ pad, provider }: BlockNoteContentProps) => {
   const { userData } = useAuthStore();
   const { setEditor, padsStore } = usePadStore();
+  useSavePad(pad.id, provider.doc);
 
   const storedEditor = padsStore?.[pad.id]?.editor;
   const editor = useMemo(() => {

--- a/src/frontend/apps/impress/src/features/pads/pad/components/BlockNoteEditor.tsx
+++ b/src/frontend/apps/impress/src/features/pads/pad/components/BlockNoteEditor.tsx
@@ -23,7 +23,7 @@ export const BlockNoteEditor = ({ pad }: BlockNoteEditorProps) => {
   const provider = padsStore?.[pad.id]?.provider;
 
   if (!provider) {
-    createProvider(pad.id);
+    createProvider(pad.id, pad.content);
     return null;
   }
 

--- a/src/frontend/apps/impress/src/features/pads/pad/hook/useSavePad.tsx
+++ b/src/frontend/apps/impress/src/features/pads/pad/hook/useSavePad.tsx
@@ -1,0 +1,83 @@
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import * as Y from 'yjs';
+
+import { useUpdatePad } from '../api/useUpdatePad';
+import { toBase64 } from '../utils';
+
+const useSavePad = (padId: string, doc: Y.Doc) => {
+  const { mutate: updatePad } = useUpdatePad();
+  const [initialDoc, setInitialDoc] = useState<string>(
+    toBase64(Y.encodeStateAsUpdate(doc)),
+  );
+
+  /**
+   * Update initial doc when doc is updated by other users,
+   * so only the user typing will trigger the save.
+   * This is to avoid saving the same doc multiple time.
+   */
+  useEffect(() => {
+    const onUpdate = (
+      _uintArray: Uint8Array,
+      _pluginKey: string,
+      updatedDoc: Y.Doc,
+      transaction: Y.Transaction,
+    ) => {
+      if (!transaction.local) {
+        setInitialDoc(toBase64(Y.encodeStateAsUpdate(updatedDoc)));
+      }
+    };
+
+    doc.on('update', onUpdate);
+
+    return () => {
+      doc.off('update', onUpdate);
+    };
+  }, [doc]);
+
+  const savePad = useCallback(() => {
+    const newDoc = toBase64(Y.encodeStateAsUpdate(doc));
+
+    /**
+     * Save only if the doc has changed.
+     */
+    if (initialDoc === newDoc) {
+      return;
+    }
+
+    setInitialDoc(newDoc);
+
+    updatePad({
+      id: padId,
+      content: newDoc,
+    });
+  }, [initialDoc, padId, doc, updatePad]);
+
+  const timeout = useRef<NodeJS.Timeout>();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (timeout.current) {
+      clearTimeout(timeout.current);
+    }
+
+    const onSave = () => {
+      savePad();
+    };
+
+    // Save every minute
+    timeout.current = setInterval(onSave, 60000);
+    // Save when the user leaves the page
+    addEventListener('beforeunload', onSave);
+    // Save when the user navigates to another page
+    router.events.on('routeChangeStart', onSave);
+
+    return () => {
+      clearTimeout(timeout.current);
+      removeEventListener('beforeunload', onSave);
+      router.events.off('routeChangeStart', onSave);
+    };
+  }, [router.events, savePad]);
+};
+
+export default useSavePad;

--- a/src/frontend/apps/impress/src/features/pads/pad/stores/usePadStore.tsx
+++ b/src/frontend/apps/impress/src/features/pads/pad/stores/usePadStore.tsx
@@ -5,7 +5,7 @@ import { create } from 'zustand';
 
 import { signalingUrl } from '@/core';
 
-import { Pad } from '../types';
+import { Base64, Pad } from '../types';
 
 export interface PadStore {
   padsStore: {
@@ -14,7 +14,7 @@ export interface PadStore {
       editor?: BlockNoteEditor;
     };
   };
-  createProvider: (padId: Pad['id']) => WebrtcProvider;
+  createProvider: (padId: Pad['id'], initialDoc: Base64) => WebrtcProvider;
   setEditor: (padId: Pad['id'], editor: BlockNoteEditor) => void;
 }
 
@@ -24,8 +24,14 @@ const initialState = {
 
 export const usePadStore = create<PadStore>((set) => ({
   padsStore: initialState.padsStore,
-  createProvider: (padId: string) => {
-    const provider = new WebrtcProvider(padId, new Y.Doc(), {
+  createProvider: (padId: string, initialDoc: Base64) => {
+    const doc = new Y.Doc();
+
+    if (initialDoc) {
+      Y.applyUpdate(doc, Buffer.from(initialDoc, 'base64'));
+    }
+
+    const provider = new WebrtcProvider(padId, doc, {
       signaling: [signalingUrl()],
     });
 

--- a/src/frontend/apps/impress/src/features/pads/pad/types.tsx
+++ b/src/frontend/apps/impress/src/features/pads/pad/types.tsx
@@ -17,9 +17,13 @@ export enum Role {
   OWNER = 'owner',
 }
 
+export type Base64 = string;
+
 export interface Pad {
   id: string;
   title: string;
+  content: Base64;
+  is_public: boolean;
   accesses: Access[];
   created_at: string;
   updated_at: string;

--- a/src/frontend/apps/impress/src/features/pads/pad/utils.ts
+++ b/src/frontend/apps/impress/src/features/pads/pad/utils.ts
@@ -22,3 +22,7 @@ function hslToHex(h: number, s: number, l: number) {
   };
   return `#${f(0)}${f(8)}${f(4)}`;
 }
+
+export const toBase64 = (
+  str: WithImplicitCoercion<ArrayBuffer | SharedArrayBuffer>,
+) => Buffer.from(str).toString('base64');

--- a/src/frontend/apps/impress/src/features/pads/pads-create/api/useCreatePad.tsx
+++ b/src/frontend/apps/impress/src/features/pads/pads-create/api/useCreatePad.tsx
@@ -3,10 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { APIError, errorCauses, fetchAPI } from '@/api';
 import { KEY_LIST_PAD, Pad } from '@/features/pads';
 
-type CreatePadParam = {
-  title: string;
-  is_public: boolean;
-};
+type CreatePadParam = Pick<Pad, 'title' | 'is_public'>;
 
 export const createPad = async ({
   title,

--- a/src/frontend/apps/impress/src/pages/pads/[id].tsx
+++ b/src/frontend/apps/impress/src/pages/pads/[id].tsx
@@ -15,7 +15,7 @@ const Page: NextPageWithLayout = () => {
   } = useRouter();
 
   if (typeof id !== 'string') {
-    throw new Error('Invalid pad id');
+    return null;
   }
 
   return <Pad id={id} />;


### PR DESCRIPTION
## Purpose

This PR manage the persistance of the documents.
We save the documents in different ways:
- when the user close the tab or the browser
- when the user leave the page (go to another pad by example)
- every 1 minute
----
- We save the documents only if the pad has been modified.
- Documents are collaborative, to not save multiple times the same pad, we save the pad only if the user is the last to have modified the pad.
----
Because of the collaborative aspect of the pads, the best way to store our pad is to save the Y.Doc, to do so the recommended way is to convert the Y.Doc to a Uint8Array and then to a string (base64). 
Our pad are saved as a string in a object in a Minio bucket.

## Proposal

- [x] Save the documents
- [x] Restore the documents
- [x] tests frontend
- [ ] Minio set version expiration 
