### PR TITLE
✨(backend) search users

### DIFF
--- a/.github/workflows/impress.yml
+++ b/.github/workflows/impress.yml
@@ -93,11 +93,11 @@ jobs:
       - name: Install development dependencies
         run: pip install --user .[dev]
       - name: Check code formatting with ruff
-        run: ~/.local/bin/ruff format impress --diff
+        run: ~/.local/bin/ruff format . --diff
       - name: Lint code with ruff
-        run: ~/.local/bin/ruff check impress
+        run: ~/.local/bin/ruff check .
       - name: Lint code with pylint
-        run: ~/.local/bin/pylint impress
+        run: ~/.local/bin/pylint .
 
 
   test-back:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - Update document (#68)
 - Remove document (#68)
 - (docker) dockerize dev frontend (#63)
+- (backend) list users with email filtering (#79)
 
 ## Changed
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -3,7 +3,6 @@ from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import exceptions, serializers
-from timezone_field.rest_framework import TimeZoneSerializerField
 
 from core import models
 
@@ -11,18 +10,10 @@ from core import models
 class UserSerializer(serializers.ModelSerializer):
     """Serialize users."""
 
-    timezone = TimeZoneSerializerField(use_pytz=False, required=True)
-
     class Meta:
         model = models.User
-        fields = [
-            "id",
-            "language",
-            "timezone",
-            "is_device",
-            "is_staff",
-        ]
-        read_only_fields = ["id", "is_device", "is_staff"]
+        fields = ["id", "email"]
+        read_only_fields = ["id", "email"]
 
 
 class BaseAccessSerializer(serializers.ModelSerializer):

--- a/src/backend/core/migrations/0002_create_pg_trgm_extension.py
+++ b/src/backend/core/migrations/0002_create_pg_trgm_extension.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            "CREATE EXTENSION IF NOT EXISTS pg_trgm;",
+            reverse_sql="DROP EXTENSION IF EXISTS pg_trgm;",
+        ),
+    ]

--- a/src/backend/core/tests/test_api_users.py
+++ b/src/backend/core/tests/test_api_users.py
@@ -118,10 +118,7 @@ def test_api_users_retrieve_me_authenticated():
     assert response.status_code == 200
     assert response.json() == {
         "id": str(user.id),
-        "language": user.language,
-        "timezone": str(user.timezone),
-        "is_device": False,
-        "is_staff": False,
+        "email": user.email,
     }
 
 

--- a/src/backend/demo/management/commands/create_demo.py
+++ b/src/backend/demo/management/commands/create_demo.py
@@ -1,7 +1,6 @@
 # ruff: noqa: S311, S106
 """create_demo management command"""
 
-import json
 import logging
 import random
 import time
@@ -110,10 +109,14 @@ def create_demo(stdout):
     queue = BulkQueue(stdout)
 
     with Timeit(stdout, "Creating Template"):
-        with open("demo/data/template/code.txt", "r") as text_file:
+        with open(
+            file="demo/data/template/code.txt", mode="r", encoding="utf-8"
+        ) as text_file:
             code_data = text_file.read()
 
-        with open("demo/data/template/css.txt", "r") as text_file:
+        with open(
+            file="demo/data/template/css.txt", mode="r", encoding="utf-8"
+        ) as text_file:
             css_data = text_file.read()
 
         queue.push(

--- a/src/backend/demo/tests/test_commands_create_demo.py
+++ b/src/backend/demo/tests/test_commands_create_demo.py
@@ -1,7 +1,5 @@
 """Test the `create_demo` management command"""
 
-from unittest import mock
-
 from django.core.management import call_command
 from django.test import override_settings
 

--- a/src/frontend/apps/impress/src/core/auth/api/types.ts
+++ b/src/frontend/apps/impress/src/core/auth/api/types.ts
@@ -8,5 +8,4 @@
 export interface User {
   id: string;
   email: string;
-  name?: string;
 }

--- a/src/frontend/apps/impress/src/features/pads/pad-editor/components/BlockNoteEditor.tsx
+++ b/src/frontend/apps/impress/src/features/pads/pad-editor/components/BlockNoteEditor.tsx
@@ -51,12 +51,12 @@ export const BlockNoteContent = ({ pad, provider }: BlockNoteContentProps) => {
         provider,
         fragment: provider.doc.getXmlFragment('document-store'),
         user: {
-          name: userData?.name || userData?.email || 'Anonymous',
+          name: userData?.email || 'Anonymous',
           color: randomColor(),
         },
       },
     });
-  }, [provider, storedEditor, userData?.email, userData?.name]);
+  }, [provider, storedEditor, userData?.email]);
 
   useEffect(() => {
     setEditor(pad.id, editor);


### PR DESCRIPTION
## Purpose

We need to be able to research users to invite them.
This PR add the route GET `/api/v1.0/users/`.
2 query params are available:
- `q` to search on `email` field
- `document_id` to exclude user that have access to a `document_id`


## Proposal

- [x] add the GET `/api/v1.0/users/`
- [x] change user serializer to get the `email` field
- [x] fix CI backend linter 