### PR TITLE
♻️(documents) store document file in object storage in a folder

### DIFF
--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -317,11 +317,18 @@ class Document(BaseModel):
         return self.title
 
     @property
+    def key_base(self):
+        """Key base of the location where the document is stored in object storage."""
+        if not self.pk:
+            raise RuntimeError(
+                "The document instance must be saved before requesting a storage key."
+            )
+        return str(self.pk)
+
+    @property
     def file_key(self):
         """Key of the object storage file to which the document content is stored"""
-        if not self.pk:
-            return None
-        return str(self.pk)
+        return f"{self.key_base}/file"
 
     @property
     def content(self):

--- a/src/backend/core/tests/test_models_documents.py
+++ b/src/backend/core/tests/test_models_documents.py
@@ -47,6 +47,12 @@ def test_models_documents_title_max_length():
         factories.DocumentFactory(title="a" * 256)
 
 
+def test_models_documents_file_key():
+    """The file key should be built from the instance uuid."""
+    document = factories.DocumentFactory(id="9531a5f1-42b1-496c-b3f4-1c09ed139b3c")
+    assert document.file_key == "9531a5f1-42b1-496c-b3f4-1c09ed139b3c/file"
+
+
 # get_abilities
 
 


### PR DESCRIPTION
## Purpose

We will need to store more than a file for a document in object storage: multiple languages, images, etc.
For this reason, the document ID should be a folder and the content a file should be stored in this folder.

## Proposal

Store document content in object storage under a folder named by the document ID. I propose to call the content file:
 `{document.id}/file`.

Thus we will be able to store the documents' images under an `images` subfolder for example:
 `{document.id}/images/{image.id}`