### PR TITLE
⚡️(e2e) remove unnecessary page.goto

### DIFF
--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-panel.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-panel.spec.ts
@@ -132,8 +132,6 @@ test.describe('Documents Panel', () => {
       }
     });
 
-    await page.goto('/');
-
     const panel = page.getByLabel('Documents panel').first();
     await expect(panel.locator('li')).toHaveCount(20);
     await panel.getByText(`My document-1-16`).click();


### PR DESCRIPTION
## Purpose

Multiple page.goto can cause flakiness.
An page.goto is already called in the beforeEach, so we don't need to call it again in the test.


