### PR TITLE
👔(service-worker) add new field to create doc

### DIFF
--- a/src/frontend/apps/impress/src/features/service-worker/ApiPlugin.ts
+++ b/src/frontend/apps/impress/src/features/service-worker/ApiPlugin.ts
@@ -179,6 +179,8 @@ export class ApiPlugin implements WorkboxPlugin {
       ...bodyMutate,
       id: uuid,
       content: '',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
       abilities: {
         destroy: true,
         versions_destroy: true,


### PR DESCRIPTION
## Purpose

We now display the creation and modification date of the document in the document grid, so when we create a new document in offline mode we need to set the dates as well.


## Demo
![image](https://github.com/numerique-gouv/impress/assets/25994652/448ba4ad-dbe0-4285-87ed-8eafe8261872)
