### PR TITLE
✨Doc grid actions

### DIFF
--- a/.github/workflows/impress-frontend.yml
+++ b/.github/workflows/impress-frontend.yml
@@ -1,4 +1,4 @@
-name: impress Workflow
+name: Frontend Workflow
 
 on:
   push:

--- a/.github/workflows/impress.yml
+++ b/.github/workflows/impress.yml
@@ -1,4 +1,4 @@
-name: impress Workflow
+name: Main Workflow
 
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - 🤡(demo) generate dummy documents on dev users #120 
 - ✨(frontend) create side modal component #134
+- ✨(frontend) Doc grid actions (update / delete) #136
 
 ## Changed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - "1081:1080"
 
   minio:
-    # user: ${DOCKER_USER:-1000}
+    user: ${DOCKER_USER:-1000}
     image: minio/minio
     environment:
       - MINIO_ROOT_USER=impress

--- a/src/frontend/apps/e2e/__tests__/app-impress/common.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/common.ts
@@ -120,11 +120,13 @@ export const goToGridDoc = async (
   const header = page.locator('header').first();
   await header.locator('h2').getByText('Docs').click();
 
-  const rows = page
+  const datagrid = page
     .getByLabel('Datagrid of the documents page 1')
-    .getByRole('table')
-    .getByRole('row');
+    .getByRole('table');
 
+  await expect(datagrid.getByLabel('Loading data')).toBeHidden();
+
+  const rows = datagrid.getByRole('row');
   const row = title
     ? rows.filter({
         hasText: title,

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-create.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-create.spec.ts
@@ -62,6 +62,8 @@ test.describe('Doc Create', () => {
       .getByLabel('Datagrid of the documents page 1')
       .getByRole('table');
 
+    await expect(datagrid.getByLabel('Loading data')).toBeHidden();
+
     await expect(datagrid.getByText(docTitle)).toBeVisible();
 
     const row = datagrid.getByRole('row').filter({

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-grid.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-grid.spec.ts
@@ -171,14 +171,9 @@ test.describe('Documents Grid', () => {
     const responsePage1 = await responsePromisePage1;
     expect(responsePage1.ok()).toBeTruthy();
 
-    const docNamePage1 = datagridPage1
-      .getByRole('row')
-      .nth(1)
-      .getByRole('cell')
-      .nth(1);
-
-    await expect(docNamePage1).toHaveText(/.*/);
-    const textDocNamePage1 = await docNamePage1.textContent();
+    await expect(
+      datagridPage1.getByRole('row').nth(1).getByRole('cell').nth(1),
+    ).toHaveText(/.*/);
 
     await page.getByLabel('Go to page 2').click();
 
@@ -189,17 +184,62 @@ test.describe('Documents Grid', () => {
     const responsePage2 = await responsePromisePage2;
     expect(responsePage2.ok()).toBeTruthy();
 
-    const docNamePage2 = datagridPage2
-      .getByRole('row')
-      .nth(1)
-      .getByRole('cell')
-      .nth(1);
+    await expect(
+      datagridPage2.getByRole('row').nth(1).getByRole('cell').nth(1),
+    ).toHaveText(/.*/);
+  });
 
-    await expect(datagridPage2.getByLabel('Loading data')).toBeHidden();
+  test('it updates document', async ({ page }) => {
+    const datagrid = page
+      .getByLabel('Datagrid of the documents page 1')
+      .getByRole('table');
 
-    await expect(docNamePage2).toHaveText(/.*/);
-    const textDocNamePage2 = await docNamePage2.textContent();
+    const docRow = datagrid.getByRole('row').nth(1).getByRole('cell');
 
-    expect(textDocNamePage1 !== textDocNamePage2).toBeTruthy();
+    const docName = await docRow.nth(1).textContent();
+
+    await docRow.getByLabel('Open the document options').click();
+
+    await page.getByText('Update document').click();
+
+    await page.getByLabel('Document name').fill(`${docName} updated`);
+
+    await page.getByText('Validate the modification').click();
+
+    await expect(datagrid.getByText(`${docName} updated`)).toBeVisible();
+  });
+
+  test('it deletes the document', async ({ page }) => {
+    const datagrid = page
+      .getByLabel('Datagrid of the documents page 1')
+      .getByRole('table');
+
+    const docRow = datagrid.getByRole('row').nth(1).getByRole('cell');
+
+    const docName = await docRow.nth(1).textContent();
+
+    await docRow.getByLabel('Open the document options').click();
+
+    await page
+      .getByRole('button', {
+        name: 'Delete document',
+      })
+      .click();
+
+    await expect(
+      page.locator('h2').getByText(`Deleting the document "${docName}"`),
+    ).toBeVisible();
+
+    await page
+      .getByRole('button', {
+        name: 'Confirm deletion',
+      })
+      .click();
+
+    await expect(
+      page.getByText('The document has been deleted.'),
+    ).toBeVisible();
+
+    await expect(datagrid.getByText(docName!)).toBeHidden();
   });
 });

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-grid.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-grid.spec.ts
@@ -125,8 +125,10 @@ test.describe('Documents Grid', () => {
       expect(
         textDocNameRow1Asc &&
           textDocNameRow2Asc &&
-          textDocNameRow1Asc.toLocaleLowerCase() <=
-            textDocNameRow2Asc.toLocaleLowerCase(),
+          textDocNameRow1Asc.localeCompare(textDocNameRow2Asc, 'en', {
+            caseFirst: 'false',
+            ignorePunctuation: true,
+          }) <= 0,
       ).toBeTruthy();
 
       // Ordering Desc
@@ -145,8 +147,10 @@ test.describe('Documents Grid', () => {
       expect(
         textDocNameRow1Desc &&
           textDocNameRow2Desc &&
-          textDocNameRow1Desc.toLocaleLowerCase() >=
-            textDocNameRow2Desc.toLocaleLowerCase(),
+          textDocNameRow1Desc.localeCompare(textDocNameRow2Desc, 'en', {
+            caseFirst: 'false',
+            ignorePunctuation: true,
+          }) >= 0,
       ).toBeTruthy();
     });
   });

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-member-grid.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-member-grid.spec.ts
@@ -90,6 +90,8 @@ test.describe('Document grid members', () => {
 
     await goToGridDoc(page);
 
+    await expect(page.locator('h2').getByText('Mocked document')).toBeVisible();
+
     await page.getByLabel('Open the document options').click();
     await page.getByRole('button', { name: 'Manage members' }).click();
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-tools.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-tools.spec.ts
@@ -123,9 +123,11 @@ test.describe('Doc Tools', () => {
       page.getByText('The document has been updated.'),
     ).toBeVisible();
 
-    await goToGridDoc(page, {
+    const docTitle = await goToGridDoc(page, {
       title: `${randomDoc}-updated`,
     });
+
+    await expect(page.locator('h2').getByText(docTitle)).toBeVisible();
 
     await page.getByLabel('Open the document options').click();
     await page

--- a/src/frontend/apps/impress/src/components/SideModal.tsx
+++ b/src/frontend/apps/impress/src/components/SideModal.tsx
@@ -22,15 +22,12 @@ const SideModalStyle = createGlobalStyle<SideModalStyleProps>`
 
 type SideModalType = Omit<ComponentPropsWithRef<typeof Modal>, 'size'>;
 
-interface SideModalProps extends SideModalType {
-  side: 'left' | 'right';
-  width: string;
-}
+type SideModalProps = SideModalType & Partial<SideModalStyleProps>;
 
 export const SideModal = ({
   children,
-  side,
-  width,
+  side = 'right',
+  width = '35vw',
   ...modalProps
 }: PropsWithChildren<SideModalProps>) => {
   return (

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGrid.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGrid.tsx
@@ -17,6 +17,8 @@ import {
 
 import { PAGE_SIZE } from '../conf';
 
+import { DocsGridActions } from './DocsGridActions';
+
 const DocsGridStyle = createGlobalStyle`
   & .c__datagrid{
     max-height: 91%;
@@ -189,6 +191,12 @@ export const DocsGrid = () => {
                   <Text $weight="bold">{row.accesses.length}</Text>
                 </StyledLink>
               );
+            },
+          },
+          {
+            id: 'column-actions',
+            renderCell: ({ row }) => {
+              return <DocsGridActions doc={row} />;
             },
           },
         ]}

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridActions.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridActions.tsx
@@ -1,0 +1,71 @@
+import { Button } from '@openfun/cunningham-react';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Box, DropButton, IconOptions, Text } from '@/components';
+import {
+  Doc,
+  ModalRemoveDoc,
+  ModalUpdateDoc,
+} from '@/features/docs/doc-management';
+
+interface DocsGridActionsProps {
+  doc: Doc;
+}
+
+export const DocsGridActions = ({ doc }: DocsGridActionsProps) => {
+  const { t } = useTranslation();
+  const [isModalUpdateOpen, setIsModalUpdateOpen] = useState(false);
+  const [isModalRemoveOpen, setIsModalRemoveOpen] = useState(false);
+  const [isDropOpen, setIsDropOpen] = useState(false);
+
+  return (
+    <>
+      <DropButton
+        button={
+          <IconOptions
+            isOpen={isDropOpen}
+            aria-label={t('Open the document options')}
+          />
+        }
+        onOpenChange={(isOpen) => setIsDropOpen(isOpen)}
+        isOpen={isDropOpen}
+      >
+        <Box>
+          {doc.abilities.partial_update && (
+            <Button
+              onClick={() => {
+                setIsModalUpdateOpen(true);
+                setIsDropOpen(false);
+              }}
+              color="primary-text"
+              icon={<span className="material-icons">edit</span>}
+              size="small"
+            >
+              <Text $theme="primary">{t('Update document')}</Text>
+            </Button>
+          )}
+          {doc.abilities.destroy && (
+            <Button
+              onClick={() => {
+                setIsModalRemoveOpen(true);
+                setIsDropOpen(false);
+              }}
+              color="primary-text"
+              icon={<span className="material-icons">delete</span>}
+              size="small"
+            >
+              <Text $theme="primary">{t('Delete document')}</Text>
+            </Button>
+          )}
+        </Box>
+      </DropButton>
+      {isModalUpdateOpen && (
+        <ModalUpdateDoc onClose={() => setIsModalUpdateOpen(false)} doc={doc} />
+      )}
+      {isModalRemoveOpen && (
+        <ModalRemoveDoc onClose={() => setIsModalRemoveOpen(false)} doc={doc} />
+      )}
+    </>
+  );
+};


### PR DESCRIPTION
## Purpose

Add document action buttons to the document grid:
- [x] update document
- [x] delete document
- [x] tests


## Demo 

[scrnli_7_9_2024_11-32-02 AM.webm](https://github.com/numerique-gouv/impress/assets/25994652/446829a0-b965-45d6-bf78-7e766ffb5205)

