### PR TITLE
✨Versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to
 ## Added
 
 - 🎨(frontend) better conversion editor to pdf #151
+- ✨(frontend) Versioning #147
+
+## Fixed
+
+- 🐛(y-webrtc) fix prob connection #147
 
 ## [1.1.0] - 2024-07-15
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -259,3 +259,12 @@ class InvitationSerializer(serializers.ModelSerializer):
         attrs["document_id"] = document_id
         attrs["issuer"] = user
         return attrs
+
+
+class DocumentVersionSerializer(serializers.Serializer):
+    """Serialize Versions."""
+
+    etag = serializers.CharField()
+    is_latest = serializers.BooleanField()
+    last_modified = serializers.DateTimeField()
+    version_id = serializers.CharField()

--- a/src/backend/core/tests/test_api_document_versions.py
+++ b/src/backend/core/tests/test_api_document_versions.py
@@ -125,7 +125,8 @@ def test_api_document_versions_list_authenticated_related(via, mock_user_get_tea
 
     assert response.status_code == 200
     content = response.json()
-    assert len(content["versions"]) == 0
+    assert len(content["results"]) == 0
+    assert content["count"] == 0
 
     # Add a new version to the document
     document.content = "new content"
@@ -137,9 +138,8 @@ def test_api_document_versions_list_authenticated_related(via, mock_user_get_tea
 
     assert response.status_code == 200
     content = response.json()
-    assert len(content["versions"]) == 1
-    assert content["next_version_id_marker"] == ""
-    assert content["is_truncated"] is False
+    assert len(content["results"]) == 1
+    assert content["count"] == 1
 
 
 def test_api_document_versions_retrieve_anonymous_public():

--- a/src/frontend/apps/e2e/__tests__/app-impress/common.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/common.ts
@@ -140,3 +140,34 @@ export const goToGridDoc = async (
 
   return docTitle as string;
 };
+
+export const mockedDocument = async (page: Page, json: object) => {
+  await page.route('**/documents/**/', async (route) => {
+    const request = route.request();
+    if (request.method().includes('GET') && !request.url().includes('page=')) {
+      await route.fulfill({
+        json: {
+          id: 'b0df4343-c8bd-4c20-9ff6-fbf94fc94egg',
+          content: '',
+          title: 'Mocked document',
+          accesses: [],
+          abilities: {
+            destroy: false, // Means not owner
+            versions_destroy: false,
+            versions_list: true,
+            versions_retrieve: true,
+            manage_accesses: false, // Means not admin
+            update: false,
+            partial_update: false, // Means not editor
+            retrieve: true,
+          },
+          is_public: false,
+          created_at: '2021-09-01T09:00:00Z',
+          ...json,
+        },
+      });
+    } else {
+      await route.continue();
+    }
+  });
+};

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-editor.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-editor.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { createDoc, goToGridDoc } from './common';
+import { createDoc, goToGridDoc, mockedDocument } from './common';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/');
@@ -153,34 +153,17 @@ test.describe('Doc Editor', () => {
   });
 
   test('it cannot edit if viewer', async ({ page }) => {
-    await page.route('**/documents/**/', async (route) => {
-      const request = route.request();
-      if (
-        request.method().includes('GET') &&
-        !request.url().includes('page=')
-      ) {
-        await route.fulfill({
-          json: {
-            id: 'b0df4343-c8bd-4c20-9ff6-fbf94fc94egg',
-            content: '',
-            title: 'Mocked document',
-            accesses: [],
-            abilities: {
-              destroy: false, // Means not owner
-              versions_destroy: false,
-              versions_list: true,
-              versions_retrieve: true,
-              manage_accesses: false, // Means not admin
-              update: false,
-              partial_update: false, // Means not editor
-              retrieve: true,
-            },
-            is_public: false,
-          },
-        });
-      } else {
-        await route.continue();
-      }
+    await mockedDocument(page, {
+      abilities: {
+        destroy: false, // Means not owner
+        versions_destroy: false,
+        versions_list: true,
+        versions_retrieve: true,
+        manage_accesses: false, // Means not admin
+        update: false,
+        partial_update: false, // Means not editor
+        retrieve: true,
+      },
     });
 
     await goToGridDoc(page);

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-header.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-header.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { goToGridDoc } from './common';
+import { goToGridDoc, mockedDocument } from './common';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/');
@@ -8,57 +8,42 @@ test.beforeEach(async ({ page }) => {
 
 test.describe('Doc Header', () => {
   test('it checks the element are correctly displayed', async ({ page }) => {
-    await page.route('**/documents/**/', async (route) => {
-      const request = route.request();
-      if (
-        request.method().includes('GET') &&
-        !request.url().includes('page=')
-      ) {
-        await route.fulfill({
-          json: {
-            id: 'b0df4343-c8bd-4c20-9ff6-fbf94fc94egg',
-            content: '',
-            title: 'Mocked document',
-            accesses: [
-              {
-                id: 'b0df4343-c8bd-4c20-9ff6-fbf94fc94egg',
-                role: 'owner',
-                user: {
-                  email: 'super@owner.com',
-                },
-              },
-              {
-                id: 'b0df4343-c8bd-4c20-9ff6-fbf94fc94egg',
-                role: 'admin',
-                user: {
-                  email: 'super@admin.com',
-                },
-              },
-              {
-                id: 'b0df4343-c8bd-4c20-9ff6-fbf94fc94egg',
-                role: 'owner',
-                user: {
-                  email: 'super2@owner.com',
-                },
-              },
-            ],
-            abilities: {
-              destroy: true, // Means owner
-              versions_destroy: true,
-              versions_list: true,
-              versions_retrieve: true,
-              manage_accesses: true,
-              update: true,
-              partial_update: true,
-              retrieve: true,
-            },
-            is_public: true,
-            created_at: '2021-09-01T09:00:00Z',
+    await mockedDocument(page, {
+      accesses: [
+        {
+          id: 'b0df4343-c8bd-4c20-9ff6-fbf94fc94egg',
+          role: 'owner',
+          user: {
+            email: 'super@owner.com',
           },
-        });
-      } else {
-        await route.continue();
-      }
+        },
+        {
+          id: 'b0df4343-c8bd-4c20-9ff6-fbf94fc94egg',
+          role: 'admin',
+          user: {
+            email: 'super@admin.com',
+          },
+        },
+        {
+          id: 'b0df4343-c8bd-4c20-9ff6-fbf94fc94egg',
+          role: 'owner',
+          user: {
+            email: 'super2@owner.com',
+          },
+        },
+      ],
+      abilities: {
+        destroy: true, // Means owner
+        versions_destroy: true,
+        versions_list: true,
+        versions_retrieve: true,
+        manage_accesses: true,
+        update: true,
+        partial_update: true,
+        retrieve: true,
+      },
+      is_public: true,
+      created_at: '2021-09-01T09:00:00Z',
     });
 
     await goToGridDoc(page);

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-tools.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-tools.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 import cs from 'convert-stream';
 import pdf from 'pdf-parse';
 
-import { createDoc, goToGridDoc } from './common';
+import { createDoc, goToGridDoc, mockedDocument } from './common';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/');
@@ -200,34 +200,17 @@ test.describe('Doc Tools', () => {
   });
 
   test('it checks the options available if administrator', async ({ page }) => {
-    await page.route('**/documents/**/', async (route) => {
-      const request = route.request();
-      if (
-        request.method().includes('GET') &&
-        !request.url().includes('page=')
-      ) {
-        await route.fulfill({
-          json: {
-            id: 'b0df4343-c8bd-4c20-9ff6-fbf94fc94egg',
-            content: '',
-            title: 'Mocked document',
-            accesses: [],
-            abilities: {
-              destroy: false, // Means not owner
-              versions_destroy: true,
-              versions_list: true,
-              versions_retrieve: true,
-              manage_accesses: true, // Means admin
-              update: true,
-              partial_update: true,
-              retrieve: true,
-            },
-            is_public: false,
-          },
-        });
-      } else {
-        await route.continue();
-      }
+    await mockedDocument(page, {
+      abilities: {
+        destroy: false, // Means not owner
+        versions_destroy: true,
+        versions_list: true,
+        versions_retrieve: true,
+        manage_accesses: true, // Means admin
+        update: true,
+        partial_update: true,
+        retrieve: true,
+      },
     });
 
     await goToGridDoc(page);
@@ -250,34 +233,17 @@ test.describe('Doc Tools', () => {
   });
 
   test('it checks the options available if editor', async ({ page }) => {
-    await page.route('**/documents/**/', async (route) => {
-      const request = route.request();
-      if (
-        request.method().includes('GET') &&
-        !request.url().includes('page=')
-      ) {
-        await route.fulfill({
-          json: {
-            id: 'b0df4343-c8bd-4c20-9ff6-fbf94fc94egg',
-            content: '',
-            title: 'Mocked document',
-            accesses: [],
-            abilities: {
-              destroy: false, // Means not owner
-              versions_destroy: true,
-              versions_list: true,
-              versions_retrieve: true,
-              manage_accesses: false, // Means not admin
-              update: true,
-              partial_update: true, // Means editor
-              retrieve: true,
-            },
-            is_public: false,
-          },
-        });
-      } else {
-        await route.continue();
-      }
+    await mockedDocument(page, {
+      abilities: {
+        destroy: false, // Means not owner
+        versions_destroy: true,
+        versions_list: true,
+        versions_retrieve: true,
+        manage_accesses: false, // Means not admin
+        update: true,
+        partial_update: true, // Means editor
+        retrieve: true,
+      },
     });
 
     await goToGridDoc(page);
@@ -300,34 +266,17 @@ test.describe('Doc Tools', () => {
   });
 
   test('it checks the options available if reader', async ({ page }) => {
-    await page.route('**/documents/**/', async (route) => {
-      const request = route.request();
-      if (
-        request.method().includes('GET') &&
-        !request.url().includes('page=')
-      ) {
-        await route.fulfill({
-          json: {
-            id: 'b0df4343-c8bd-4c20-9ff6-fbf94fc94egg',
-            content: '',
-            title: 'Mocked document',
-            accesses: [],
-            abilities: {
-              destroy: false, // Means not owner
-              versions_destroy: false,
-              versions_list: true,
-              versions_retrieve: true,
-              manage_accesses: false, // Means not admin
-              update: false,
-              partial_update: false, // Means not editor
-              retrieve: true,
-            },
-            is_public: false,
-          },
-        });
-      } else {
-        await route.continue();
-      }
+    await mockedDocument(page, {
+      abilities: {
+        destroy: false, // Means not owner
+        versions_destroy: false,
+        versions_list: true,
+        versions_retrieve: true,
+        manage_accesses: false, // Means not admin
+        update: false,
+        partial_update: false, // Means not editor
+        retrieve: true,
+      },
     });
 
     await goToGridDoc(page);

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-version.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-version.spec.ts
@@ -66,4 +66,41 @@ test.describe('Doc Version', () => {
 
     await expect(page.getByLabel('Document version panel')).toBeHidden();
   });
+
+  test('it restores the doc version', async ({ page, browserName }) => {
+    const [randomDoc] = await createDoc(page, 'doc-version', browserName, 1);
+
+    await expect(page.locator('h2').getByText(randomDoc)).toBeVisible();
+
+    await page.locator('.bn-block-outer').last().click();
+    await page.locator('.bn-block-outer').last().fill('Hello');
+
+    await goToGridDoc(page, {
+      title: randomDoc,
+    });
+
+    await expect(page.getByText('Hello')).toBeVisible();
+    await page.locator('.bn-block-outer').last().click();
+    await page.keyboard.press('Enter');
+    await page.locator('.bn-block-outer').last().fill('World');
+
+    await goToGridDoc(page, {
+      title: randomDoc,
+    });
+
+    await expect(page.getByText('World')).toBeVisible();
+
+    const panel = page.getByLabel('Document version panel');
+    await panel.locator('li').nth(1).click();
+    await expect(page.getByText('World')).toBeHidden();
+
+    await panel.getByLabel('Open the version options').click();
+    await page.getByText('Restore the version').click();
+
+    await expect(panel.locator('li')).toHaveCount(3);
+
+    await panel.getByText('Current version').click();
+    await expect(page.getByText('Hello')).toBeVisible();
+    await expect(page.getByText('World')).toBeHidden();
+  });
 });

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-version.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-version.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test';
+
+import { createDoc, goToGridDoc, mockedDocument } from './common';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+});
+
+test.describe('Doc Version', () => {
+  test('it displays the doc versions', async ({ page, browserName }) => {
+    const [randomDoc] = await createDoc(page, 'doc-version', browserName, 1);
+
+    await expect(page.locator('h2').getByText(randomDoc)).toBeVisible();
+
+    const panel = page.getByLabel('Document version panel');
+
+    await expect(panel.getByText('Current version')).toBeVisible();
+    expect(await panel.locator('li').count()).toBe(1);
+
+    await page.locator('.ProseMirror.bn-editor').click();
+    await page.locator('.ProseMirror.bn-editor').last().fill('Hello World');
+
+    await goToGridDoc(page, {
+      title: randomDoc,
+    });
+
+    await expect(page.getByText('Hello World')).toBeVisible();
+
+    await page
+      .locator('.ProseMirror.bn-editor')
+      .last()
+      .fill('It will create a version');
+
+    await goToGridDoc(page, {
+      title: randomDoc,
+    });
+
+    await expect(page.getByText('Hello World')).toBeHidden();
+    await expect(page.getByText('It will create a version')).toBeVisible();
+
+    await expect(panel.getByText('Current version')).toBeVisible();
+    expect(await panel.locator('li').count()).toBe(2);
+
+    await panel.locator('li').nth(1).click();
+    await expect(page.getByText('Hello World')).toBeVisible();
+    await expect(page.getByText('It will create a version')).toBeHidden();
+
+    await panel.getByText('Current version').click();
+    await expect(page.getByText('Hello World')).toBeHidden();
+    await expect(page.getByText('It will create a version')).toBeVisible();
+  });
+
+  test('it does not display the doc versions if not allowed', async ({
+    page,
+  }) => {
+    await mockedDocument(page, {
+      abilities: {
+        versions_list: false,
+        partial_update: true,
+      },
+    });
+
+    await goToGridDoc(page);
+
+    await expect(page.locator('h2').getByText('Mocked document')).toBeVisible();
+
+    await expect(page.getByLabel('Document version panel')).toBeHidden();
+  });
+});

--- a/src/frontend/apps/impress/conf/default.conf
+++ b/src/frontend/apps/impress/conf/default.conf
@@ -8,6 +8,10 @@ server {
       try_files $uri index.html $uri/ =404;
   }
 
+  location ~ ^/docs/(.*)/versions/(.*)/$ {
+    error_page 404 /docs/[id]/versions/[versionId]/;
+  }
+
   location /docs/ {
     error_page 404 /docs/[id]/;
   }

--- a/src/frontend/apps/impress/src/api/helpers.tsx
+++ b/src/frontend/apps/impress/src/api/helpers.tsx
@@ -1,0 +1,46 @@
+import {
+  DefinedInitialDataInfiniteOptions,
+  InfiniteData,
+  QueryKey,
+  UseQueryOptions,
+  useInfiniteQuery,
+} from '@tanstack/react-query';
+
+import { APIError } from './APIError';
+import { APIList } from './types';
+
+export type UseQueryOptionsAPI<Q> = UseQueryOptions<Q, APIError, Q>;
+export type DefinedInitialDataInfiniteOptionsAPI<Q> =
+  DefinedInitialDataInfiniteOptions<
+    Q,
+    APIError,
+    InfiniteData<Q>,
+    QueryKey,
+    number
+  >;
+
+/**
+ * @param param Used for infinite scroll pagination
+ * @param queryConfig
+ * @returns
+ */
+export const useAPIInfiniteQuery = <T, Q extends { next?: APIList<Q>['next'] }>(
+  key: string,
+  api: (props: T & { page: number }) => Promise<Q>,
+  param: T,
+  queryConfig?: DefinedInitialDataInfiniteOptionsAPI<Q>,
+) => {
+  return useInfiniteQuery<Q, APIError, InfiniteData<Q>, QueryKey, number>({
+    initialPageParam: 1,
+    queryKey: [key, param],
+    queryFn: ({ pageParam }) =>
+      api({
+        ...param,
+        page: pageParam,
+      }),
+    getNextPageParam(lastPage, allPages) {
+      return lastPage.next ? allPages.length + 1 : undefined;
+    },
+    ...queryConfig,
+  });
+};

--- a/src/frontend/apps/impress/src/api/index.ts
+++ b/src/frontend/apps/impress/src/api/index.ts
@@ -1,4 +1,5 @@
 export * from './APIError';
 export * from './fetchApi';
+export * from './helpers';
 export * from './types';
 export * from './utils';

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
@@ -38,7 +38,7 @@ interface BlockNoteContentProps {
 
 export const BlockNoteContent = ({ doc, provider }: BlockNoteContentProps) => {
   const { userData } = useAuthStore();
-  const { setEditor, docsStore } = useDocStore();
+  const { setStore, docsStore } = useDocStore();
   useSaveDoc(doc.id, provider.doc, doc.abilities.partial_update);
 
   const storedEditor = docsStore?.[doc.id]?.editor;
@@ -60,8 +60,8 @@ export const BlockNoteContent = ({ doc, provider }: BlockNoteContentProps) => {
   }, [provider, storedEditor, userData?.email]);
 
   useEffect(() => {
-    setEditor(doc.id, editor);
-  }, [setEditor, doc.id, editor]);
+    setStore(doc.id, { editor });
+  }, [setStore, doc.id, editor]);
 
   return (
     <Box

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/DocEditor.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/DocEditor.tsx
@@ -1,9 +1,18 @@
-import { Alert, VariantType } from '@openfun/cunningham-react';
+import { Alert, Loader, VariantType } from '@openfun/cunningham-react';
+import { useRouter as useNavigate } from 'next/navigation';
+import { useRouter } from 'next/router';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
-import { Box, Card } from '@/components';
+import { Box, Card, Text, TextErrors } from '@/components';
+import { useCunninghamTheme } from '@/cunningham';
 import { DocHeader } from '@/features/docs/doc-header';
 import { Doc } from '@/features/docs/doc-management';
+import {
+  Panel,
+  Versions,
+  useDocVersion,
+} from '@/features/docs/doc-versioning/';
 
 import { BlockNoteEditor } from './BlockNoteEditor';
 
@@ -12,24 +21,101 @@ interface DocEditorProps {
 }
 
 export const DocEditor = ({ doc }: DocEditorProps) => {
+  const {
+    query: { versionId },
+  } = useRouter();
+
+  const { t } = useTranslation();
+
+  const isVersion = versionId && typeof versionId === 'string';
+
+  const { colorsTokens } = useCunninghamTheme();
+
   return (
     <>
       <DocHeader doc={doc} />
       {!doc.abilities.partial_update && (
         <Box $margin={{ all: 'small', top: 'none' }}>
-          <Alert
-            type={VariantType.WARNING}
-          >{`Read only, you don't have the right to update this document.`}</Alert>
+          <Alert type={VariantType.WARNING}>
+            {t(`Read only, you don't have the right to update this document.`)}
+          </Alert>
         </Box>
       )}
-      <Card
-        $margin={{ all: 'big', top: 'none' }}
-        $padding="big"
-        $css="flex:1;"
+      {isVersion && (
+        <Box $margin={{ all: 'small', top: 'none' }}>
+          <Alert type={VariantType.WARNING}>
+            {t(`You cannot edit document version.`)}
+          </Alert>
+        </Box>
+      )}
+      <Box
+        $background={colorsTokens()['primary-bg']}
+        $height="100%"
+        $direction="row"
+        $margin={{ all: 'small', top: 'none' }}
+        $gap="1rem"
         $overflow="auto"
       >
-        <BlockNoteEditor doc={doc} />
-      </Card>
+        <Card $padding="big" $css="flex:1;" $overflow="auto">
+          {isVersion ? (
+            <DocVersionEditor doc={doc} versionId={versionId} />
+          ) : (
+            <BlockNoteEditor doc={doc} />
+          )}
+        </Card>
+        {doc.abilities.versions_list && <Panel doc={doc} />}
+      </Box>
     </>
   );
+};
+
+interface DocVersionEditorProps {
+  doc: Doc;
+  versionId: Versions['version_id'];
+}
+
+export const DocVersionEditor = ({ doc, versionId }: DocVersionEditorProps) => {
+  const {
+    data: version,
+    isLoading,
+    isError,
+    error,
+  } = useDocVersion({
+    docId: doc.id,
+    versionId,
+  });
+
+  const navigate = useNavigate();
+
+  if (isError && error) {
+    if (error.status === 404) {
+      navigate.replace(`/404`);
+      return null;
+    }
+
+    return (
+      <Box $margin="large">
+        <TextErrors
+          causes={error.cause}
+          icon={
+            error.status === 502 ? (
+              <Text className="material-icons" $theme="danger">
+                wifi_off
+              </Text>
+            ) : undefined
+          }
+        />
+      </Box>
+    );
+  }
+
+  if (isLoading || !version) {
+    return (
+      <Box $align="center" $justify="center" $height="100%">
+        <Loader />
+      </Box>
+    );
+  }
+
+  return <BlockNoteEditor doc={doc} version={version} />;
 };

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/hook/useSaveDoc.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/hook/useSaveDoc.tsx
@@ -4,7 +4,8 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as Y from 'yjs';
 
-import { useUpdateDoc } from '@/features/docs/doc-management/';
+import { KEY_DOC, useUpdateDoc } from '@/features/docs/doc-management/';
+import { KEY_LIST_DOC_VERSIONS } from '@/features/docs/doc-versioning';
 
 import { toBase64 } from '../utils';
 
@@ -21,6 +22,7 @@ const useSaveDoc = (docId: string, doc: Y.Doc, canSave: boolean) => {
         VariantType.SUCCESS,
       );
     },
+    listInvalideQueries: [KEY_LIST_DOC_VERSIONS, KEY_DOC],
   });
   const [initialDoc, setInitialDoc] = useState<string>(
     toBase64(Y.encodeStateAsUpdate(doc)),

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/stores/useDocStore.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/stores/useDocStore.tsx
@@ -11,16 +11,24 @@ interface DocStore {
   editor?: BlockNoteEditor;
 }
 
+type ForceSaveState = 'false' | 'version' | 'current';
+
 export interface UseDocStore {
   docsStore: {
     [storeId: string]: DocStore;
   };
   createProvider: (storeId: string, initialDoc: Base64) => WebrtcProvider;
   setStore: (storeId: string, props: Partial<DocStore>) => void;
+  forceSave: ForceSaveState;
+  setForceSave: (forceSave: ForceSaveState) => void;
 }
 
 export const useDocStore = create<UseDocStore>((set, get) => ({
   docsStore: {},
+  forceSave: 'false',
+  setForceSave: (forceSave) => {
+    set(() => ({ forceSave }));
+  },
   createProvider: (storeId: string, initialDoc: Base64) => {
     const doc = new Y.Doc({
       guid: storeId,

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/stores/useDocStore.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/stores/useDocStore.tsx
@@ -4,7 +4,7 @@ import * as Y from 'yjs';
 import { create } from 'zustand';
 
 import { signalingUrl } from '@/core';
-import { Base64, Doc } from '@/features/docs/doc-management';
+import { Base64 } from '@/features/docs/doc-management';
 
 interface DocStore {
   provider: WebrtcProvider;
@@ -13,43 +13,39 @@ interface DocStore {
 
 export interface UseDocStore {
   docsStore: {
-    [docId: Doc['id']]: DocStore;
+    [storeId: string]: DocStore;
   };
-  createProvider: (docId: Doc['id'], initialDoc: Base64) => WebrtcProvider;
-  setStore: (docId: Doc['id'], props: Partial<DocStore>) => void;
+  createProvider: (storeId: string, initialDoc: Base64) => WebrtcProvider;
+  setStore: (storeId: string, props: Partial<DocStore>) => void;
 }
 
-const initialState = {
-  docsStore: {},
-};
-
 export const useDocStore = create<UseDocStore>((set, get) => ({
-  docsStore: initialState.docsStore,
-  createProvider: (docId: string, initialDoc: Base64) => {
+  docsStore: {},
+  createProvider: (storeId: string, initialDoc: Base64) => {
     const doc = new Y.Doc({
-      guid: docId,
+      guid: storeId,
     });
 
     if (initialDoc) {
       Y.applyUpdate(doc, Buffer.from(initialDoc, 'base64'));
     }
 
-    const provider = new WebrtcProvider(docId, doc, {
-      signaling: [signalingUrl(docId)],
+    const provider = new WebrtcProvider(storeId, doc, {
+      signaling: [signalingUrl(storeId)],
       maxConns: 5,
     });
 
-    get().setStore(docId, { provider });
+    get().setStore(storeId, { provider });
 
     return provider;
   },
-  setStore: (docId, props) => {
+  setStore: (storeId, props) => {
     set(({ docsStore }) => {
       return {
         docsStore: {
           ...docsStore,
-          [docId]: {
-            ...docsStore[docId],
+          [storeId]: {
+            ...docsStore[storeId],
             ...props,
           },
         },

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/DocHeader.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/DocHeader.tsx
@@ -25,7 +25,7 @@ export const DocHeader = ({ doc }: DocHeaderProps) => {
 
   return (
     <Card
-      $margin="big"
+      $margin="small"
       aria-label={t('It is the card information about the document.')}
     >
       <Box $padding="small" $direction="row" $align="center">

--- a/src/frontend/apps/impress/src/features/docs/doc-versioning/api/index.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-versioning/api/index.ts
@@ -1,1 +1,2 @@
 export * from './useDocVersions';
+export * from './useDocVersion';

--- a/src/frontend/apps/impress/src/features/docs/doc-versioning/api/index.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-versioning/api/index.ts
@@ -1,0 +1,1 @@
+export * from './useDocVersions';

--- a/src/frontend/apps/impress/src/features/docs/doc-versioning/api/useDocVersion.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-versioning/api/useDocVersion.tsx
@@ -1,0 +1,41 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { APIError, UseQueryOptionsAPI, errorCauses, fetchAPI } from '@/api';
+
+import { Version } from '../types';
+
+export type DocVersionParam = {
+  docId: string;
+  versionId: string;
+};
+
+const getDocVersion = async ({
+  versionId,
+  docId,
+}: DocVersionParam): Promise<Version> => {
+  const url = `documents/${docId}/versions/${versionId}/`;
+
+  const response = await fetchAPI(url);
+
+  if (!response.ok) {
+    throw new APIError(
+      'Failed to get the doc version',
+      await errorCauses(response),
+    );
+  }
+
+  return response.json() as Promise<Version>;
+};
+
+export const KEY_DOC_VERSION = 'doc-version';
+
+export function useDocVersion(
+  params: DocVersionParam,
+  queryConfig?: UseQueryOptionsAPI<Version>,
+) {
+  return useQuery<Version, APIError, Version>({
+    queryKey: [KEY_DOC_VERSION, params],
+    queryFn: () => getDocVersion(params),
+    ...queryConfig,
+  });
+}

--- a/src/frontend/apps/impress/src/features/docs/doc-versioning/api/useDocVersions.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-versioning/api/useDocVersions.tsx
@@ -1,0 +1,66 @@
+import { useQuery } from '@tanstack/react-query';
+
+import {
+  APIError,
+  APIList,
+  DefinedInitialDataInfiniteOptionsAPI,
+  UseQueryOptionsAPI,
+  errorCauses,
+  fetchAPI,
+  useAPIInfiniteQuery,
+} from '@/api';
+
+import { Versions } from '../types';
+
+export type DocVersionsParam = {
+  docId: string;
+};
+
+export type DocVersionsAPIParams = DocVersionsParam & {
+  page: number;
+};
+
+type VersionsResponse = APIList<Versions>;
+
+const getDocVersions = async ({
+  page,
+  docId,
+}: DocVersionsAPIParams): Promise<VersionsResponse> => {
+  const url = `documents/${docId}/versions/?page=${page}`;
+
+  const response = await fetchAPI(url);
+
+  if (!response.ok) {
+    throw new APIError(
+      'Failed to get the doc versions',
+      await errorCauses(response),
+    );
+  }
+
+  return response.json() as Promise<VersionsResponse>;
+};
+
+export const KEY_LIST_DOC_VERSIONS = 'doc-versions';
+
+export function useDocVersions(
+  params: DocVersionsAPIParams,
+  queryConfig?: UseQueryOptionsAPI<VersionsResponse>,
+) {
+  return useQuery<VersionsResponse, APIError, VersionsResponse>({
+    queryKey: [KEY_LIST_DOC_VERSIONS, params],
+    queryFn: () => getDocVersions(params),
+    ...queryConfig,
+  });
+}
+
+export function useDocVersionsInfiniteQuery(
+  param: DocVersionsParam,
+  queryConfig?: DefinedInitialDataInfiniteOptionsAPI<VersionsResponse>,
+) {
+  return useAPIInfiniteQuery<DocVersionsParam, VersionsResponse>(
+    KEY_LIST_DOC_VERSIONS,
+    getDocVersions,
+    param,
+    queryConfig,
+  );
+}

--- a/src/frontend/apps/impress/src/features/docs/doc-versioning/components/Panel.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-versioning/components/Panel.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Box, Card, IconBG, Text } from '@/components';
+import { useCunninghamTheme } from '@/cunningham';
+import { Doc } from '@/features/docs/doc-management';
+
+import { VersionList } from './VersionList';
+
+interface PanelProps {
+  doc: Doc;
+}
+
+export const Panel = ({ doc }: PanelProps) => {
+  const { t } = useTranslation();
+  const { colorsTokens } = useCunninghamTheme();
+
+  const [isOpen, setIsOpen] = useState(true);
+
+  const closedOverridingStyles = !isOpen && {
+    $width: '0',
+    $maxWidth: '0',
+    $minWidth: '0',
+  };
+
+  const transition = 'all 0.5s ease-in-out';
+
+  return (
+    <Card
+      $width="100%"
+      $maxWidth="20rem"
+      $position="relative"
+      $css={`
+        transition: ${transition};
+        ${
+          !isOpen &&
+          `
+            box-shadow: none;
+            border: none;
+          `
+        }
+      `}
+      aria-label={t('Document version panel')}
+      {...closedOverridingStyles}
+    >
+      <IconBG
+        iconName="menu_open"
+        aria-label={
+          isOpen
+            ? t('Close the document version panel')
+            : t('Open the document version panel')
+        }
+        $background="white"
+        $size="h2"
+        $zIndex={1}
+        $css={`
+          cursor: pointer;
+          left: ${isOpen ? '0' : '-3.3'}rem;
+          top: 0.1rem;
+          transform: rotate(${isOpen ? '180' : '0'}deg);
+          transition: ${transition};
+          user-select: none;
+        `}
+        $position="absolute"
+        onClick={() => setIsOpen(!isOpen)}
+        $radius="2px"
+      />
+      <Box
+        $overflow="hidden"
+        $css={`
+          opacity: ${isOpen ? '1' : '0'};
+          transition: ${transition};
+        `}
+      >
+        <Box
+          $padding={{ all: 'small' }}
+          $direction="row"
+          $align="center"
+          $justify="center"
+          $css={`border-top: 2px solid ${colorsTokens()['primary-600']};`}
+        >
+          <Text $weight="bold" $size="l" $theme="primary">
+            {t('VERSIONS')}
+          </Text>
+        </Box>
+        <VersionList doc={doc} />
+      </Box>
+    </Card>
+  );
+};

--- a/src/frontend/apps/impress/src/features/docs/doc-versioning/components/VersionItem.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-versioning/components/VersionItem.tsx
@@ -1,0 +1,65 @@
+import { useRouter } from 'next/router';
+import React from 'react';
+
+import { Box, StyledLink, Text } from '@/components';
+import { useCunninghamTheme } from '@/cunningham';
+
+import { Versions } from '../types';
+
+interface VersionItemProps {
+  text: string;
+  link: string;
+  versionId?: Versions['version_id'];
+}
+
+export const VersionItem = ({ versionId, text, link }: VersionItemProps) => {
+  const { colorsTokens } = useCunninghamTheme();
+  const {
+    query: { versionId: currentId },
+  } = useRouter();
+
+  const isActive = versionId === currentId;
+
+  return (
+    <Box
+      as="li"
+      $background={isActive ? colorsTokens()['primary-300'] : 'transparent'}
+      $css={`
+        border-left: 4px solid transparent;
+        border-bottom: 1px solid ${colorsTokens()['primary-100']};
+        &:hover{
+          border-left: 4px solid ${colorsTokens()['primary-400']};
+          background: ${colorsTokens()['primary-300']};
+        }
+      `}
+      $hasTransition
+      $minWidth="13rem"
+    >
+      <StyledLink
+        href={link}
+        onClick={(e) => {
+          if (isActive) {
+            e.preventDefault();
+          }
+        }}
+      >
+        <Box
+          $padding={{ vertical: '0.7rem', horizontal: 'small' }}
+          $align="center"
+          $direction="row"
+          $justify="space-between"
+          $width="100%"
+        >
+          <Box $direction="row" $gap="0.5rem" $align="center">
+            <Text $isMaterialIcon $size="24px" $theme="primary">
+              description
+            </Text>
+            <Text $weight="bold" $theme="primary" $size="m">
+              {text}
+            </Text>
+          </Box>
+        </Box>
+      </StyledLink>
+    </Box>
+  );
+};

--- a/src/frontend/apps/impress/src/features/docs/doc-versioning/components/VersionList.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-versioning/components/VersionList.tsx
@@ -1,0 +1,123 @@
+import { Loader } from '@openfun/cunningham-react';
+import React, { useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { APIError } from '@/api';
+import { Box, InfiniteScroll, Text, TextErrors } from '@/components';
+import { Doc } from '@/features/docs/doc-management';
+import { useDate } from '@/hook';
+
+import { useDocVersionsInfiniteQuery } from '../api/useDocVersions';
+import { Versions } from '../types';
+
+import { VersionItem } from './VersionItem';
+
+interface VersionListStateProps {
+  isLoading: boolean;
+  error: APIError<unknown> | null;
+  versions?: Versions[];
+  doc: Doc;
+}
+
+const VersionListState = ({
+  isLoading,
+  error,
+  versions,
+  doc,
+}: VersionListStateProps) => {
+  const { t } = useTranslation();
+  const { formatDate } = useDate();
+
+  if (isLoading) {
+    return (
+      <Box $align="center" $margin="large">
+        <Loader />
+      </Box>
+    );
+  }
+
+  return (
+    <>
+      <VersionItem
+        text={t('Current version')}
+        versionId={undefined}
+        link={`/docs/${doc.id}/`}
+      />
+      {versions?.map((version) => (
+        <VersionItem
+          key={version.version_id}
+          versionId={version.version_id}
+          text={formatDate(version.last_modified, {
+            dateStyle: 'long',
+            timeStyle: 'short',
+          })}
+          link={`/docs/${doc.id}/versions/${version.version_id}`}
+        />
+      ))}
+      {error && (
+        <Box
+          $justify="center"
+          $margin={{ vertical: 'big', horizontal: 'auto' }}
+        >
+          <TextErrors
+            causes={error.cause}
+            icon={
+              error.status === 502 ? (
+                <Text $isMaterialIcon $theme="danger">
+                  wifi_off
+                </Text>
+              ) : undefined
+            }
+          />
+        </Box>
+      )}
+    </>
+  );
+};
+
+interface VersionListProps {
+  doc: Doc;
+}
+
+export const VersionList = ({ doc }: VersionListProps) => {
+  const {
+    data,
+    error,
+    isLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useDocVersionsInfiniteQuery({
+    docId: doc.id,
+  });
+  const containerRef = useRef<HTMLDivElement>(null);
+  const versions = useMemo(() => {
+    return data?.pages.reduce((acc, page) => {
+      return acc.concat(page.results);
+    }, [] as Versions[]);
+  }, [data?.pages]);
+
+  return (
+    <Box $css="overflow-y: auto; overflow-x: hidden;" ref={containerRef}>
+      <InfiniteScroll
+        hasMore={hasNextPage}
+        isLoading={isFetchingNextPage}
+        next={() => {
+          void fetchNextPage();
+        }}
+        scrollContainer={containerRef.current}
+        as="ul"
+        $padding="none"
+        $margin={{ top: 'none' }}
+        role="listbox"
+      >
+        <VersionListState
+          isLoading={isLoading}
+          error={error}
+          versions={versions}
+          doc={doc}
+        />
+      </InfiniteScroll>
+    </Box>
+  );
+};

--- a/src/frontend/apps/impress/src/features/docs/doc-versioning/components/VersionList.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-versioning/components/VersionList.tsx
@@ -1,4 +1,5 @@
 import { Loader } from '@openfun/cunningham-react';
+import { useRouter } from 'next/router';
 import React, { useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -27,6 +28,9 @@ const VersionListState = ({
 }: VersionListStateProps) => {
   const { t } = useTranslation();
   const { formatDate } = useDate();
+  const {
+    query: { versionId },
+  } = useRouter();
 
   if (isLoading) {
     return (
@@ -42,6 +46,8 @@ const VersionListState = ({
         text={t('Current version')}
         versionId={undefined}
         link={`/docs/${doc.id}/`}
+        docId={doc.id}
+        isActive={!versionId}
       />
       {versions?.map((version) => (
         <VersionItem
@@ -52,6 +58,8 @@ const VersionListState = ({
             timeStyle: 'short',
           })}
           link={`/docs/${doc.id}/versions/${version.version_id}`}
+          docId={doc.id}
+          isActive={version.version_id === versionId}
         />
       ))}
       {error && (

--- a/src/frontend/apps/impress/src/features/docs/doc-versioning/components/index.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-versioning/components/index.ts
@@ -1,0 +1,1 @@
+export * from './Panel';

--- a/src/frontend/apps/impress/src/features/docs/doc-versioning/index.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-versioning/index.ts
@@ -1,0 +1,3 @@
+export * from './api';
+export * from './components';
+export * from './types';

--- a/src/frontend/apps/impress/src/features/docs/doc-versioning/types.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-versioning/types.ts
@@ -1,0 +1,13 @@
+import { Doc } from '../doc-management';
+
+export interface Versions {
+  etag: string;
+  is_latest: boolean;
+  last_modified: string;
+  version_id: string;
+}
+
+export interface Version {
+  content: Doc['content'];
+  last_modified: string;
+}

--- a/src/frontend/apps/impress/src/features/docs/doc-versioning/types.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-versioning/types.ts
@@ -10,4 +10,5 @@ export interface Versions {
 export interface Version {
   content: Doc['content'];
   last_modified: string;
+  id: string;
 }

--- a/src/frontend/apps/impress/src/features/docs/doc-versioning/utils.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-versioning/utils.ts
@@ -1,0 +1,53 @@
+import * as Y from 'yjs';
+
+/**
+ * Revert the doc to a previous state.
+ *
+ * We cannot simply replace a doc with another previous doc,
+ * because Y.js will act as if the previous doc is a new doc and so
+ * merge it with the current doc, so we need to revert the doc (undo).
+ *
+ * To do so we simulate a history of the doc by saving snapshots of the doc
+ * and then revert the doc to a previous snapshot.
+ *
+ * @param doc
+ * @param snapshotOrigin
+ * @param snapshotUpdate
+ */
+export function revertUpdate(
+  doc: Y.Doc,
+  snapshotOrigin: Y.Doc,
+  snapshotUpdate: Y.Doc,
+) {
+  try {
+    const snapshotDoc = new Y.Doc();
+    Y.applyUpdate(
+      snapshotDoc,
+      Y.encodeStateAsUpdate(snapshotUpdate),
+      snapshotOrigin,
+    );
+
+    const currentStateVector = Y.encodeStateVector(doc);
+    const snapshotStateVector = Y.encodeStateVector(snapshotDoc);
+
+    const changesSinceSnapshotUpdate = Y.encodeStateAsUpdate(
+      doc,
+      snapshotStateVector,
+    );
+
+    const undoManager = new Y.UndoManager(
+      [snapshotDoc.getMap('document-store')],
+      {
+        trackedOrigins: new Set([snapshotOrigin]),
+      },
+    );
+
+    Y.applyUpdate(snapshotDoc, changesSinceSnapshotUpdate, snapshotOrigin);
+    undoManager.undo();
+    const revertChangesSinceSnapshotUpdate = Y.encodeStateAsUpdate(
+      snapshotDoc,
+      currentStateVector,
+    );
+    Y.applyUpdate(doc, revertChangesSinceSnapshotUpdate, snapshotOrigin);
+  } catch (e) {}
+}

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGrid.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGrid.tsx
@@ -193,6 +193,7 @@ export const DocsGrid = () => {
         pagination={pagination}
         onSortModelChange={setSortModel}
         sortModel={sortModel}
+        emptyPlaceholderLabel={t("You don't have any document yet.")}
       />
     </Card>
   );

--- a/src/frontend/apps/impress/src/features/docs/members/members-list/api/useUpdateDocAccess.ts
+++ b/src/frontend/apps/impress/src/features/docs/members/members-list/api/useUpdateDocAccess.ts
@@ -5,7 +5,12 @@ import {
 } from '@tanstack/react-query';
 
 import { APIError, errorCauses, fetchAPI } from '@/api';
-import { Access, KEY_DOC, Role } from '@/features/docs/doc-management';
+import {
+  Access,
+  KEY_DOC,
+  KEY_LIST_DOC,
+  Role,
+} from '@/features/docs/doc-management';
 
 import { KEY_LIST_DOC_ACCESSES } from './useDocAccesses';
 
@@ -53,6 +58,9 @@ export const useUpdateDocAccess = (options?: UseUpdateDocAccessOptions) => {
       });
       void queryClient.invalidateQueries({
         queryKey: [KEY_DOC],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: [KEY_LIST_DOC],
       });
       if (options?.onSuccess) {
         options.onSuccess(data, variables, context);

--- a/src/frontend/apps/impress/src/hook/useDate.tsx
+++ b/src/frontend/apps/impress/src/hook/useDate.tsx
@@ -1,7 +1,7 @@
 import { DateTime, DateTimeFormatOptions } from 'luxon';
 import { useTranslation } from 'react-i18next';
 
-const format: DateTimeFormatOptions = {
+const formatDefault: DateTimeFormatOptions = {
   month: '2-digit',
   day: '2-digit',
   year: 'numeric',
@@ -12,7 +12,10 @@ const format: DateTimeFormatOptions = {
 export const useDate = () => {
   const { i18n } = useTranslation();
 
-  const formatDate = (date: string): string => {
+  const formatDate = (
+    date: string,
+    format: DateTimeFormatOptions = formatDefault,
+  ): string => {
     return DateTime.fromISO(date)
       .setLocale(i18n.language)
       .toLocaleString(format);

--- a/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
+++ b/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
@@ -1,15 +1,15 @@
 import { Loader } from '@openfun/cunningham-react';
 import { useRouter as useNavigate } from 'next/navigation';
 import { useRouter } from 'next/router';
-import { ReactElement } from 'react';
 
-import { Box, Text, TextErrors } from '@/components/';
-import { DocEditor } from '@/features/docs/doc-editor';
+import { Box, Text } from '@/components';
+import { TextErrors } from '@/components/TextErrors';
+import { DocEditor } from '@/features/docs';
 import { useDoc } from '@/features/docs/doc-management';
 import { MainLayout } from '@/layouts';
 import { NextPageWithLayout } from '@/types/next';
 
-const Page: NextPageWithLayout = () => {
+export function DocLayout() {
   const {
     query: { id },
   } = useRouter();
@@ -18,14 +18,18 @@ const Page: NextPageWithLayout = () => {
     return null;
   }
 
-  return <Doc id={id} />;
-};
+  return (
+    <MainLayout>
+      <DocPage id={id} />
+    </MainLayout>
+  );
+}
 
 interface DocProps {
   id: string;
 }
 
-const Doc = ({ id }: DocProps) => {
+const DocPage = ({ id }: DocProps) => {
   const { data: doc, isLoading, isError, error } = useDoc({ id });
   const navigate = useNavigate();
 
@@ -41,7 +45,7 @@ const Doc = ({ id }: DocProps) => {
           causes={error.cause}
           icon={
             error.status === 502 ? (
-              <Text className="material-icons" $theme="danger">
+              <Text $isMaterialIcon $theme="danger">
                 wifi_off
               </Text>
             ) : undefined
@@ -62,8 +66,12 @@ const Doc = ({ id }: DocProps) => {
   return <DocEditor doc={doc} />;
 };
 
-Page.getLayout = function getLayout(page: ReactElement) {
-  return <MainLayout>{page}</MainLayout>;
+const Page: NextPageWithLayout = () => {
+  return null;
+};
+
+Page.getLayout = function getLayout() {
+  return <DocLayout />;
 };
 
 export default Page;

--- a/src/frontend/apps/impress/src/pages/docs/[id]/versions/[versionId].tsx
+++ b/src/frontend/apps/impress/src/pages/docs/[id]/versions/[versionId].tsx
@@ -1,0 +1,13 @@
+import { NextPageWithLayout } from '@/types/next';
+
+import { DocLayout } from '../index';
+
+const Page: NextPageWithLayout = () => {
+  return null;
+};
+
+Page.getLayout = function getLayout() {
+  return <DocLayout />;
+};
+
+export default Page;

--- a/src/frontend/apps/impress/src/pages/docs/[id]/versions/index.tsx
+++ b/src/frontend/apps/impress/src/pages/docs/[id]/versions/index.tsx
@@ -1,0 +1,13 @@
+import { NextPageWithLayout } from '@/types/next';
+
+import { DocLayout } from '../index';
+
+const Page: NextPageWithLayout = () => {
+  return null;
+};
+
+Page.getLayout = function getLayout() {
+  return <DocLayout />;
+};
+
+export default Page;

--- a/src/frontend/apps/impress/src/pages/globals.css
+++ b/src/frontend/apps/impress/src/pages/globals.css
@@ -31,3 +31,13 @@ main ::-webkit-scrollbar-thumb:hover,
 .ReactModalPortal ::-webkit-scrollbar-thumb:hover {
   background-color: #a8bbbf;
 }
+
+.btn-unstyled {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  outline: inherit;
+}

--- a/src/frontend/apps/y-webrtc-signaling/nodemon.json
+++ b/src/frontend/apps/y-webrtc-signaling/nodemon.json
@@ -1,5 +1,5 @@
 {
   "watch": ["src"],
   "ext": "ts",
-  "exec": "ts-node --esm ./src/server.ts"
+  "exec": "yarn build"
 }

--- a/src/frontend/apps/y-webrtc-signaling/package.json
+++ b/src/frontend/apps/y-webrtc-signaling/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc -p .",
-    "dev": "nodemon --exec src/server.ts",
+    "dev": "nodemon --config nodemon.json",
     "start": "node ./dist/server.js",
     "lint": "eslint . --ext .ts"
   },

--- a/src/frontend/apps/y-webrtc-signaling/src/server.ts
+++ b/src/frontend/apps/y-webrtc-signaling/src/server.ts
@@ -68,7 +68,7 @@ const onconnection = (conn: WebSocket, url: string) => {
     subscribedTopics.forEach((topicName) => {
       const subs = topics.get(topicName) || new Set();
       subs.forEach((sub) => {
-        if (sub.conn === conn) {
+        if (sub.url === url && sub.conn === conn) {
           subs.delete(sub);
         }
       });
@@ -96,9 +96,18 @@ const onconnection = (conn: WebSocket, url: string) => {
                 topicName,
                 () => new Set(),
               );
-              topic.add({ url, conn });
-              // add topic to conn
-              subscribedTopics.add(topicName);
+
+              let isAlreadyAdded = false;
+              topic.forEach((sub) => {
+                if (sub.url === url && sub.conn === conn) {
+                  isAlreadyAdded = true;
+                }
+              });
+
+              if (!isAlreadyAdded) {
+                topic.add({ url, conn });
+                subscribedTopics.add(topicName);
+              }
             }
           });
           break;


### PR DESCRIPTION
## Purpose

Integrate the versioning on the front side.

We will plug the versions to the router, we will have a specific url per version. 
Thanks to that, we will be able to plug it with the webrtc server, so we will be able to do collaboration and editing directly on a version without impacted the main version. We can at every moment merge a version to the "main version".

## Proposal

- [x] 👔(backend) add document version serializer to get the pagination
- [x] 👔(frontend) create versions api endpoints
- [x] ✨(frontend) navigate on different version directly from the router
- [x] 🗃️(frontend) replace main version per another version
- [x] tests

## Demo

[scrnli_8_6_2024_9-17-54 AM.webm](https://github.com/user-attachments/assets/13c9d82a-e8b7-434b-8380-2d83fccfda19)




