### PR TITLE
🔖(minor) release to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.2.0] - 2024-08-06
+
 ## Added
 
 - 🎨(frontend) better conversion editor to pdf #151
@@ -47,6 +49,7 @@ and this project adheres to
 - ♻️(frontend) create a doc from a modal #132
 - ♻️(frontend) manage members from the share modal #140
 
+
 ## [1.0.0] - 2024-07-02
 
 ## Added
@@ -85,6 +88,7 @@ and this project adheres to
 - 💚(CI) Remove trigger workflow on push tags on CI (#68)
 - 🔥(frontend) Remove coming soon page (#121)
 
+
 ## [0.1.0] - 2024-05-24
 
 ## Added
@@ -93,7 +97,8 @@ and this project adheres to
 - 🚀 Impress, project to manage your documents easily and collaboratively.
 
 
-[unreleased]: https://github.com/numerique-gouv/impress/compare/v1.1.0...main
+[unreleased]: https://github.com/numerique-gouv/impress/compare/v1.2.0...main
+[1.2.0]: https://github.com/numerique-gouv/impress/releases/v1.2.0
 [1.1.0]: https://github.com/numerique-gouv/impress/releases/v1.1.0
 [1.0.0]: https://github.com/numerique-gouv/impress/releases/v1.0.0
 [0.1.0]: https://github.com/numerique-gouv/impress/releases/v0.1.0

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "impress"
-version = "1.1.0"
+version = "1.2.0"
 authors = [{ "name" = "DINUM", "email" = "dev@mail.numerique.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/frontend/apps/e2e/package.json
+++ b/src/frontend/apps/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-e2e",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "lint": "eslint . --ext .ts",

--- a/src/frontend/apps/impress/package.json
+++ b/src/frontend/apps/impress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-impress",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/frontend/apps/y-webrtc-signaling/package.json
+++ b/src/frontend/apps/y-webrtc-signaling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "y-webrtc-signaling",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "WebRTC server for Yjs",
   "repository": "https://github.com/numerique-gouv/impress",
   "license": "MIT",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "impress",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "workspaces": {
     "packages": [

--- a/src/frontend/packages/eslint-config-impress/package.json
+++ b/src/frontend/packages/eslint-config-impress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-impress",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "scripts": {
     "lint": "eslint --ext .js ."

--- a/src/frontend/packages/i18n/package.json
+++ b/src/frontend/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packages-i18n",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "extract-translation": "yarn extract-translation:impress",

--- a/src/helm/env.d/preprod/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/preprod/values.impress.yaml.gotmpl
@@ -1,7 +1,7 @@
 image:
   repository: lasuite/impress-backend
   pullPolicy: Always
-  tag: "v1.1.0"
+  tag: "v1.2.0"
 
 backend:
   migrateJobAnnotations:
@@ -116,13 +116,13 @@ frontend:
   image:
     repository: lasuite/impress-frontend
     pullPolicy: Always
-    tag: "v1.1.0"
+    tag: "v1.2.0"
 
 webrtc:
   image:
     repository: lasuite/impress-y-webrtc-signaling
     pullPolicy: Always
-    tag: "v1.1.0"
+    tag: "v1.2.0"
 
 ingress:
   enabled: true

--- a/src/helm/env.d/production/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/production/values.impress.yaml.gotmpl
@@ -1,7 +1,7 @@
 image:
   repository: lasuite/impress-backend
   pullPolicy: Always
-  tag: "v1.1.0"
+  tag: "v1.2.0"
 
 backend:
   migrateJobAnnotations:
@@ -116,13 +116,13 @@ frontend:
   image:
     repository: lasuite/impress-frontend
     pullPolicy: Always
-    tag: "v1.1.0"
+    tag: "v1.2.0"
 
 webrtc:
   image:
     repository: lasuite/impress-y-webrtc-signaling
     pullPolicy: Always
-    tag: "v1.1.0"
+    tag: "v1.2.0"
 
 ingress:
   enabled: true

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Added

- 🎨(frontend) better conversion editor to pdf #151
- ✨Export docx (word) #161
- 🌐Internationalize invitation email #167
- ✨(frontend) White branding #164
- ✨Email invitation when add user to doc #171
- ✨Invitation management #174

## Fixed

- 🐛(y-webrtc) fix prob connection #147
- ⚡️(frontend) improve select share stability #159
- 🐛(backend) enable SSL when sending email #165

## Changed

- 🎨(frontend) stop limit layout height to screen size #158
- ⚡️(CI) only e2e chrome mandatory #177

## Removed
- 🔥(helm) remove htaccess #181

----

**Full Changelog:** https://github.com/numerique-gouv/impress/compare/v1.1.0...v1.2.0
