### PR TITLE
🐛(backend) enable SSL when sending email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 
 - 🐛(y-webrtc) fix prob connection #147
 - ⚡️(frontend) improve select share stability #159
+- 🐛(backend) enable SSL when sending email #165
 
 ## Changed
 

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -805,7 +805,7 @@ class Invitation(BaseModel):
         """Email invitation to the user."""
         try:
             with override(self.issuer.language):
-                title = _("Invitation to join Impress!")
+                title = _("Invitation to join Docs!")
                 template_vars = {"title": title, "site": Site.objects.get_current()}
                 msg_html = render_to_string("mail/html/invitation.html", template_vars)
                 msg_plain = render_to_string("mail/text/invitation.txt", template_vars)

--- a/src/backend/core/tests/test_models_invitations.py
+++ b/src/backend/core/tests/test_models_invitations.py
@@ -186,10 +186,10 @@ def test_models_document_invitations_email():
     email = mail.outbox[0]
 
     assert email.to == [invitation.email]
-    assert email.subject == "Invitation to join Impress!"
+    assert email.subject == "Invitation to join Docs!"
 
     email_content = " ".join(email.body.split())
-    assert "Invitation to join Impress!" in email_content
+    assert "Invitation to join Docs!" in email_content
     assert "[//example.com]" in email_content
 
 

--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -278,6 +278,7 @@ class Base(Configuration):
     EMAIL_HOST_PASSWORD = values.Value(None)
     EMAIL_PORT = values.PositiveIntegerValue(None)
     EMAIL_USE_TLS = values.BooleanValue(False)
+    EMAIL_USE_SSL = values.BooleanValue(False)
     EMAIL_FROM = values.Value("from@example.com")
 
     AUTH_USER_MODEL = "core.User"

--- a/src/helm/env.d/preprod/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/preprod/values.impress.yaml.gotmpl
@@ -27,6 +27,7 @@ backend:
     DJANGO_EMAIL_HOST: "snap-mail.numerique.gouv.fr"
     DJANGO_EMAIL_PORT: 465
     DJANGO_EMAIL_USE_SSL: True
+    DJANGO_EMAIL_FROM: "noreply@docs.numerique.gouv.fr"
     DJANGO_SILENCED_SYSTEM_CHECKS: security.W008,security.W004
     OIDC_OP_JWKS_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/jwks
     OIDC_OP_AUTHORIZATION_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/authorize

--- a/src/helm/env.d/production/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/production/values.impress.yaml.gotmpl
@@ -27,6 +27,7 @@ backend:
     DJANGO_EMAIL_HOST: "snap-mail.numerique.gouv.fr"
     DJANGO_EMAIL_PORT: 465
     DJANGO_EMAIL_USE_SSL: True
+    DJANGO_EMAIL_FROM: "noreply@docs.numerique.gouv.fr"
     DJANGO_SILENCED_SYSTEM_CHECKS: security.W008,security.W004
     OIDC_OP_JWKS_ENDPOINT: https://auth.agentconnect.gouv.fr/api/v2/jwks
     OIDC_OP_AUTHORIZATION_ENDPOINT: https://auth.agentconnect.gouv.fr/api/v2/authorize

--- a/src/helm/env.d/staging/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/staging/values.impress.yaml.gotmpl
@@ -27,6 +27,7 @@ backend:
     DJANGO_EMAIL_HOST: "snap-mail.numerique.gouv.fr"
     DJANGO_EMAIL_PORT: 465
     DJANGO_EMAIL_USE_SSL: True
+    DJANGO_EMAIL_FROM: "noreply@docs.numerique.gouv.fr"
     DJANGO_SILENCED_SYSTEM_CHECKS: security.W008,security.W004
     OIDC_OP_JWKS_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/jwks
     OIDC_OP_AUTHORIZATION_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/authorize

--- a/src/mail/mjml/invitation.mjml
+++ b/src/mail/mjml/invitation.mjml
@@ -10,32 +10,30 @@
       </mj-section>
       <mj-section mj-class="bg--white-100" padding="30px 20px 60px 20px">
         <mj-column>
-          <mj-text font-size="14px">
-            <p>{% trans "Invitation to join a team" %}</p>
+          <mj-text font-size="16px">
+            <p>{% trans "Invitation to join a document !" %}</p>
           </mj-text>
 
           <!-- Welcome Message -->
           <mj-text>
-            <h1>{% blocktrans %}Welcome to <strong>Impress</strong>{% endblocktrans %}</h1>
+            <h1> {% blocktrans %}Welcome to <strong>Docs!</strong>{% endblocktrans %}</h1>
           </mj-text>
           <mj-divider border-width="1px" border-style="solid" border-color="#DDDDDD" width="30%" align="left"/>
-
-          <mj-image src="{% base64_static 'images/logo.svg' %}" width="157px" align="left" alt="{%trans 'Logo' %}" />
-
           <!-- Main Message -->
-          <mj-text>{% trans "We are delighted to welcome you to our community on Impress, your new companion to collaborate on documents efficiently, intuitively, and securely." %}</mj-text>
+          <mj-text>{% trans "We are delighted to welcome you to our community on Docs, your new companion to collaborate on documents efficiently, intuitively, and securely." %}</mj-text>
           <mj-text>{% trans "Our application is designed to help you organize, collaborate, and manage permissions." %}</mj-text>
           <mj-text>
-            {% trans "With Impress, you will be able to:" %}
+            {% trans "With Docs, you will be able to:" %}
             <ul>
               <li>{% trans "Create documents."%}</li>
+              <li>{% trans "Work offline."%}</li>
               <li>{% trans "Invite members of your document or community in just a few clicks."%}</li>
             </ul>
           </mj-text>
           <mj-button href="//{{site.domain}}" background-color="#000091" color="white" padding-bottom="30px">
-            {% trans "Visit Impress"%}
+            {% trans "Visit Docs"%}
           </mj-button>
-          <mj-text>{% trans "We are confident that Impress will help you increase efficiency and productivity while strengthening the bond among members." %}</mj-text>
+          <mj-text>{% trans "We are confident that Docs will help you increase efficiency and productivity while strengthening the bond among members." %}</mj-text>
           <mj-text>{% trans "Feel free to explore all the features of the application and share your feedback and suggestions with us. Your feedback is valuable to us and will enable us to continually improve our service." %}</mj-text>
           <mj-text>{% trans "Once again, welcome aboard! We are eager to accompany you on you collaboration adventure." %}</mj-text>
 


### PR DESCRIPTION
## Purpose

Email settings were wrongly configured. It leed to unsent email and timeout response from the backend server. 
This PR fixes the issue by enabling SSL when sending email.

## Proposal

- [x] replace occurences of Impress with Docs in the email
- [x] change the default email from.
- [x] replace occurences of Impress with Docs in the email subject
- [x] add EMAIL_USE_SSL var in settings
