### PR TITLE
⚡️(CI) only e2e chrome mandatory

### DIFF
--- a/.github/workflows/impress-frontend.yml
+++ b/.github/workflows/impress-frontend.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Check linting
         run: cd src/frontend/ && yarn lint
 
-  test-e2e:
+  test-e2e-chromium:
     runs-on: ubuntu-latest
     needs: build-front
     timeout-minutes: 20
@@ -158,14 +158,88 @@ jobs:
           make demo FLUSH_ARGS='--no-input'
 
       - name: Install Playwright Browsers
-        run: cd src/frontend/apps/e2e && yarn install
+        run: cd src/frontend/apps/e2e && yarn install-playwright chromium
 
       - name: Run e2e tests
-        run: cd src/frontend/ && yarn e2e:test
+        run: cd src/frontend/ && yarn e2e:test --project='chromium'
 
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: playwright-report
+          name: playwright-chromium-report
+          path: src/frontend/apps/e2e/report/
+          retention-days: 7
+
+  test-e2e-other-browser:
+    runs-on: ubuntu-latest
+    needs: build-front
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set services env variables
+        run: |
+          make data/media
+          make create-env-files
+          cat env.d/development/common.e2e.dist >> env.d/development/common
+
+      - name: Restore the mail templates
+        uses: actions/cache@v4
+        id: mail-templates
+        with:
+          path: "src/backend/core/templates/mail"
+          key: mail-templates-${{ hashFiles('src/mail/mjml') }}
+
+      - name: Restore the frontend cache
+        uses: actions/cache@v4
+        id: front-node_modules
+        with:
+          path: "src/frontend/**/node_modules"
+          key: front-node_modules-${{ hashFiles('src/frontend/**/yarn.lock') }}
+
+      - name: Restore the build cache
+        uses: actions/cache@v4
+        id: cache-build
+        with:
+          path: src/frontend/apps/impress/out/
+          key: build-front-${{ github.run_id }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build the Docker images
+        uses: docker/bake-action@v4
+        with:
+          targets: |
+            app-dev
+            y-webrtc-signaling
+          load: true
+          set: |
+            *.cache-from=type=gha,scope=cached-stage
+            *.cache-to=type=gha,scope=cached-stage,mode=max
+
+      - name: Start Docker services
+        run: |
+          make run
+
+      - name: Apply DRF migrations
+        run: |
+          make migrate
+
+      - name: Add dummy data
+        run: |
+          make demo FLUSH_ARGS='--no-input'
+
+      - name: Install Playwright Browsers
+        run: cd src/frontend/apps/e2e && yarn install-playwright firefox webkit chromium
+
+      - name: Run e2e tests
+        run: cd src/frontend/ && yarn e2e:test --project=firefox --project=webkit
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-other-report
           path: src/frontend/apps/e2e/report/
           retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to
 ## Changed
 
 - 🎨(frontend) stop limit layout height to screen size #158
+- ⚡️(CI) only e2e chrome mandatory #177
 
 ## [1.1.0] - 2024-07-15
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/auth.setup.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/auth.setup.ts
@@ -17,3 +17,11 @@ setup('authenticate-webkit', async ({ page }) => {
     .context()
     .storageState({ path: `playwright/.auth/user-webkit.json` });
 });
+
+setup('authenticate-firefox', async ({ page }) => {
+  await page.goto('/');
+  await keyCloakSignIn(page, 'firefox');
+  await page
+    .context()
+    .storageState({ path: `playwright/.auth/user-firefox.json` });
+});

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-version.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-version.spec.ts
@@ -27,8 +27,8 @@ test.describe('Doc Version', () => {
     await expect(page.getByText('Hello World')).toBeVisible();
 
     await page
-      .locator('.ProseMirror.bn-editor')
-      .last()
+      .locator('.ProseMirror .bn-block')
+      .getByText('Hello World')
       .fill('It will create a version');
 
     await goToGridDoc(page, {

--- a/src/frontend/apps/e2e/package.json
+++ b/src/frontend/apps/e2e/package.json
@@ -4,9 +4,12 @@
   "private": true,
   "scripts": {
     "lint": "eslint . --ext .ts",
-    "install": "playwright install --with-deps",
+    "install-playwright": "playwright install --with-deps",
     "test": "playwright test",
-    "test:ui": "yarn test --ui"
+    "test:ui": "yarn test --ui",
+    "test:ui::firefox": "yarn test:ui --project=firefox",
+    "test:ui::webkit": "yarn test:ui --project=webkit",
+    "test:ui::chromium": "yarn test:ui --project=chromium"
   },
   "devDependencies": {
     "@playwright/test": "1.45.3",

--- a/src/frontend/apps/e2e/playwright.config.ts
+++ b/src/frontend/apps/e2e/playwright.config.ts
@@ -63,5 +63,15 @@ export default defineConfig({
       },
       dependencies: ['setup'],
     },
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+        locale: 'en-US',
+        timezoneId: 'Europe/Paris',
+        storageState: 'playwright/.auth/user-firefox.json',
+      },
+      dependencies: ['setup'],
+    },
   ],
 });


### PR DESCRIPTION
## Purpose

To speed up pull request flow, put e2e tests only mandatory for Chrome.
Chrome is the fastest and more reliable browser with the e2e tests.

We still test Firefox and Webkit, but they are not mandatory.
They will still have to be checked regularly, to discern the flaky test with the one showing a bug.
Extra attention during the deployment phase.

