### PR TITLE
Add image upload and download from media url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# Added
+
+- ✨Add image attachments with access control
+
 ## [Unreleased]
 
 

--- a/src/backend/core/api/utils.py
+++ b/src/backend/core/api/utils.py
@@ -1,0 +1,33 @@
+"""Util to generate S3 authorization headers for object storage access control"""
+
+from django.core.files.storage import default_storage
+
+import botocore
+
+
+def generate_s3_authorization_headers(key):
+    """
+    Generate authorization headers for an s3 object.
+    These headers can be used as an alternative to signed urls with many benefits:
+    - the urls of our files never expire and can be stored in our documents' content
+    - we don't leak authorized urls that could be shared (file access can only be done
+      with cookies)
+    - access control is truly realtime
+    - the object storage service does not need to be exposed on internet
+    """
+    url = default_storage.unsigned_connection.meta.client.generate_presigned_url(
+        "get_object",
+        ExpiresIn=0,
+        Params={"Bucket": default_storage.bucket_name, "Key": key},
+    )
+    request = botocore.awsrequest.AWSRequest(method="get", url=url)
+
+    s3_client = default_storage.connection.meta.client
+    # pylint: disable=protected-access
+    credentials = s3_client._request_signer._credentials  # noqa: SLF001
+    frozen_credentials = credentials.get_frozen_credentials()
+    region = s3_client.meta.region_name
+    auth = botocore.auth.S3SigV4Auth(frozen_credentials, "s3", region)
+    auth.add_auth(request)
+
+    return request

--- a/src/backend/core/tests/documents/test_api_documents_attachment_upload.py
+++ b/src/backend/core/tests/documents/test_api_documents_attachment_upload.py
@@ -103,9 +103,7 @@ def test_api_documents_attachment_upload_reader(via, mock_user_get_teams):
 
 @pytest.mark.parametrize("role", ["editor", "administrator", "owner"])
 @pytest.mark.parametrize("via", VIA)
-def test_api_documents_attachment_upload_success(
-    via, role, mock_user_get_teams, settings
-):
+def test_api_documents_attachment_upload_success(via, role, mock_user_get_teams):
     """
     Editors, administrators and owners of a document should be able to upload an attachment.
     """
@@ -130,7 +128,7 @@ def test_api_documents_attachment_upload_success(
 
     assert response.status_code == 201
 
-    pattern = re.compile(rf"^{settings.MEDIA_URL}{document.id!s}/attachments/(.*)\.jpg")
+    pattern = re.compile(rf"^/media/{document.id!s}/attachments/(.*)\.jpg")
     match = pattern.search(response.json()["file"])
     file_id = match.group(1)
 

--- a/src/backend/core/tests/documents/test_api_documents_attachment_upload.py
+++ b/src/backend/core/tests/documents/test_api_documents_attachment_upload.py
@@ -1,0 +1,199 @@
+"""
+Test file uploads API endpoint for users in impress's core app.
+"""
+
+import re
+import uuid
+
+from django.core.files.base import ContentFile
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+import pytest
+from rest_framework.test import APIClient
+
+from core import factories
+from core.tests.conftest import TEAM, USER, VIA
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_documents_attachment_upload_anonymous():
+    """Anonymous users can't upload attachments to a document."""
+    document = factories.DocumentFactory()
+    file = SimpleUploadedFile("test_file.jpg", b"Dummy content")
+
+    url = f"/api/v1.0/documents/{document.id!s}/attachment-upload/"
+    response = APIClient().post(url, {"file": file}, format="multipart")
+
+    assert response.status_code == 401
+    assert response.json() == {
+        "detail": "Authentication credentials were not provided."
+    }
+
+
+def test_api_documents_attachment_upload_authenticated_public():
+    """
+    Users who are not related to a public document should not be allowed to upload an attachment.
+    """
+    user = factories.UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    document = factories.DocumentFactory(is_public=True)
+    file = SimpleUploadedFile("test_file.jpg", b"Dummy content")
+
+    url = f"/api/v1.0/documents/{document.id!s}/attachment-upload/"
+    response = client.post(url, {"file": file}, format="multipart")
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "detail": "You do not have permission to perform this action."
+    }
+
+
+def test_api_documents_attachment_upload_authenticated_private():
+    """
+    Users who are not related to a private document should not be able to upload an attachment.
+    """
+    user = factories.UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    document = factories.DocumentFactory(is_public=False)
+    file = SimpleUploadedFile("test_file.jpg", b"Dummy content")
+
+    url = f"/api/v1.0/documents/{document.id!s}/attachment-upload/"
+    response = client.post(url, {"file": file}, format="multipart")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "No Document matches the given query."}
+
+
+@pytest.mark.parametrize("via", VIA)
+def test_api_documents_attachment_upload_reader(via, mock_user_get_teams):
+    """
+    Users who are simple readers on a document should not be allowed to upload an attachment.
+    """
+    user = factories.UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    document = factories.DocumentFactory()
+    if via == USER:
+        factories.UserDocumentAccessFactory(document=document, user=user, role="reader")
+    elif via == TEAM:
+        mock_user_get_teams.return_value = ["lasuite", "unknown"]
+        factories.TeamDocumentAccessFactory(
+            document=document, team="lasuite", role="reader"
+        )
+
+    file = SimpleUploadedFile("test_file.jpg", b"Dummy content")
+
+    url = f"/api/v1.0/documents/{document.id!s}/attachment-upload/"
+    response = client.post(url, {"file": file}, format="multipart")
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "detail": "You do not have permission to perform this action."
+    }
+
+
+@pytest.mark.parametrize("role", ["editor", "administrator", "owner"])
+@pytest.mark.parametrize("via", VIA)
+def test_api_documents_attachment_upload_success(
+    via, role, mock_user_get_teams, settings
+):
+    """
+    Editors, administrators and owners of a document should be able to upload an attachment.
+    """
+    user = factories.UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    document = factories.DocumentFactory()
+    if via == USER:
+        factories.UserDocumentAccessFactory(document=document, user=user, role=role)
+    elif via == TEAM:
+        mock_user_get_teams.return_value = ["lasuite", "unknown"]
+        factories.TeamDocumentAccessFactory(
+            document=document, team="lasuite", role=role
+        )
+
+    file = SimpleUploadedFile("test_file.jpg", b"Dummy content")
+
+    url = f"/api/v1.0/documents/{document.id!s}/attachment-upload/"
+    response = client.post(url, {"file": file}, format="multipart")
+
+    assert response.status_code == 201
+
+    pattern = re.compile(rf"^{settings.MEDIA_URL}{document.id!s}/attachments/(.*)\.jpg")
+    match = pattern.search(response.json()["file"])
+    file_id = match.group(1)
+
+    # Validate that file_id is a valid UUID
+    uuid.UUID(file_id)
+
+
+def test_api_documents_attachment_upload_invalid(client):
+    """Attempt to upload without a file should return an explicit error."""
+    user = factories.UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    document = factories.DocumentFactory(users=[(user, "owner")])
+    url = f"/api/v1.0/documents/{document.id!s}/attachment-upload/"
+
+    response = client.post(url, {}, format="multipart")
+
+    assert response.status_code == 400
+    assert response.json() == {"file": ["No file was submitted."]}
+
+
+def test_api_documents_attachment_upload_size_limit_exceeded(settings):
+    """The uploaded file should not exceeed the maximum size in settings."""
+    settings.DOCUMENT_IMAGE_MAX_SIZE = 1048576  # 1 MB for test
+
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    document = factories.DocumentFactory(users=[(user, "owner")])
+    url = f"/api/v1.0/documents/{document.id!s}/attachment-upload/"
+
+    # Create a temporary file larger than the allowed size
+    content = b"a" * (1048576 + 1)
+    file = ContentFile(content, name="test.jpg")
+
+    response = client.post(url, {"file": file}, format="multipart")
+
+    assert response.status_code == 400
+    assert response.json() == {"file": ["File size exceeds the maximum limit of 1 MB."]}
+
+
+def test_api_documents_attachment_upload_type_not_allowed(settings):
+    """The uploaded file should be of a whitelisted type."""
+    settings.DOCUMENT_IMAGE_ALLOWED_MIME_TYPES = ["image/jpeg", "image/png"]
+
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    document = factories.DocumentFactory(users=[(user, "owner")])
+    url = f"/api/v1.0/documents/{document.id!s}/attachment-upload/"
+
+    # Create a temporary file with a not allowed type (e.g., text file)
+    file = ContentFile(b"a" * 1048576, name="test.txt")
+
+    response = client.post(url, {"file": file}, format="multipart")
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "file": [
+            "File type 'text/plain' is not allowed. Allowed types are: image/jpeg, image/png"
+        ]
+    }

--- a/src/backend/core/tests/documents/test_api_documents_retrieve.py
+++ b/src/backend/core/tests/documents/test_api_documents_retrieve.py
@@ -22,6 +22,7 @@ def test_api_documents_retrieve_anonymous_public():
         "id": str(document.id),
         "abilities": {
             "destroy": False,
+            "attachment_upload": False,
             "manage_accesses": False,
             "partial_update": False,
             "retrieve": True,
@@ -69,6 +70,7 @@ def test_api_documents_retrieve_authenticated_unrelated_public():
         "id": str(document.id),
         "abilities": {
             "destroy": False,
+            "attachment_upload": False,
             "manage_accesses": False,
             "partial_update": False,
             "retrieve": True,

--- a/src/backend/core/tests/documents/test_api_documents_retrieve_auth.py
+++ b/src/backend/core/tests/documents/test_api_documents_retrieve_auth.py
@@ -1,0 +1,213 @@
+"""
+Test file uploads API endpoint for users in impress's core app.
+"""
+
+import uuid
+from io import BytesIO
+from urllib.parse import urlparse
+
+from django.conf import settings
+from django.core.files.storage import default_storage
+from django.utils import timezone
+
+import pytest
+import requests
+from rest_framework.test import APIClient
+
+from core import factories
+from core.tests.conftest import TEAM, USER, VIA
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_documents_retrieve_auth_anonymous_public():
+    """Anonymous users should be able to retrieve attachments linked to a public document"""
+    document = factories.DocumentFactory(is_public=True)
+
+    filename = f"{uuid.uuid4()!s}.jpg"
+    key = f"{document.pk!s}/attachments/{filename:s}"
+
+    default_storage.connection.meta.client.put_object(
+        Bucket=default_storage.bucket_name,
+        Key=key,
+        Body=BytesIO(b"my prose"),
+        ContentType="text/plain",
+    )
+
+    original_url = f"http://localhost/media/{key:s}"
+    response = APIClient().get(
+        "/api/v1.0/documents/retrieve-auth/", HTTP_X_ORIGINAL_URL=original_url
+    )
+
+    assert response.status_code == 200
+
+    authorization = response["Authorization"]
+    assert "AWS4-HMAC-SHA256 Credential=" in authorization
+    assert (
+        "SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature="
+        in authorization
+    )
+    assert response["X-Amz-Date"] == timezone.now().strftime("%Y%m%dT%H%M%SZ")
+
+    s3_url = urlparse(settings.AWS_S3_ENDPOINT_URL)
+    file_url = f"{settings.AWS_S3_ENDPOINT_URL:s}/impress-media-storage/{key:s}"
+    response = requests.get(
+        file_url,
+        headers={
+            "authorization": authorization,
+            "x-amz-date": response["x-amz-date"],
+            "x-amz-content-sha256": response["x-amz-content-sha256"],
+            "Host": f"{s3_url.hostname:s}:{s3_url.port:d}",
+        },
+        timeout=1,
+    )
+    assert response.content.decode("utf-8") == "my prose"
+
+
+def test_api_documents_retrieve_auth_anonymous_not_public():
+    """
+    Anonymous users should not be allowed to retrieve attachments linked to a document
+    that is not public.
+    """
+    document = factories.DocumentFactory(is_public=False)
+
+    filename = f"{uuid.uuid4()!s}.jpg"
+    media_url = f"http://localhost/media/{document.pk!s}/attachments/{filename:s}"
+
+    response = APIClient().get(
+        "/api/v1.0/documents/retrieve-auth/", HTTP_X_ORIGINAL_URL=media_url
+    )
+
+    assert response.status_code == 403
+    assert "Authorization" not in response
+
+
+def test_api_documents_retrieve_auth_authenticated_public():
+    """
+    Authenticated users who are not related to a document should be able to
+    retrieve attachments linked to a public document.
+    """
+    document = factories.DocumentFactory(is_public=True)
+
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    filename = f"{uuid.uuid4()!s}.jpg"
+    key = f"{document.pk!s}/attachments/{filename:s}"
+
+    default_storage.connection.meta.client.put_object(
+        Bucket=default_storage.bucket_name,
+        Key=key,
+        Body=BytesIO(b"my prose"),
+        ContentType="text/plain",
+    )
+
+    original_url = f"http://localhost/media/{key:s}"
+    response = APIClient().get(
+        "/api/v1.0/documents/retrieve-auth/", HTTP_X_ORIGINAL_URL=original_url
+    )
+
+    assert response.status_code == 200
+
+    authorization = response["Authorization"]
+    assert "AWS4-HMAC-SHA256 Credential=" in authorization
+    assert (
+        "SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature="
+        in authorization
+    )
+    assert response["X-Amz-Date"] == timezone.now().strftime("%Y%m%dT%H%M%SZ")
+
+    s3_url = urlparse(settings.AWS_S3_ENDPOINT_URL)
+    file_url = f"{settings.AWS_S3_ENDPOINT_URL:s}/impress-media-storage/{key:s}"
+    response = requests.get(
+        file_url,
+        headers={
+            "authorization": authorization,
+            "x-amz-date": response["x-amz-date"],
+            "x-amz-content-sha256": response["x-amz-content-sha256"],
+            "Host": f"{s3_url.hostname:s}:{s3_url.port:d}",
+        },
+        timeout=1,
+    )
+    assert response.content.decode("utf-8") == "my prose"
+
+
+def test_api_documents_retrieve_auth_authenticated_not_public():
+    """
+    Authenticated users who are not related to a document should not be allowed to
+    retrieve attachments linked to a document that is not public.
+    """
+    document = factories.DocumentFactory(is_public=False)
+
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    filename = f"{uuid.uuid4()!s}.jpg"
+    media_url = f"http://localhost/media/{document.pk!s}/attachments/{filename:s}"
+
+    response = APIClient().get(
+        "/api/v1.0/documents/retrieve-auth/", HTTP_X_ORIGINAL_URL=media_url
+    )
+
+    assert response.status_code == 403
+    assert "Authorization" not in response
+
+
+@pytest.mark.parametrize("is_public", [True, False])
+@pytest.mark.parametrize("via", VIA)
+def test_api_documents_retrieve_auth_related(via, is_public, mock_user_get_teams):
+    """
+    Users who have a role on a document, whatever the role, should be able to
+    retrieve related attachments.
+    """
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    document = factories.DocumentFactory(is_public=is_public)
+    if via == USER:
+        factories.UserDocumentAccessFactory(document=document, user=user)
+    elif via == TEAM:
+        mock_user_get_teams.return_value = ["lasuite", "unknown"]
+        factories.TeamDocumentAccessFactory(document=document, team="lasuite")
+
+    filename = f"{uuid.uuid4()!s}.jpg"
+    key = f"{document.pk!s}/attachments/{filename:s}"
+
+    default_storage.connection.meta.client.put_object(
+        Bucket=default_storage.bucket_name,
+        Key=key,
+        Body=BytesIO(b"my prose"),
+        ContentType="text/plain",
+    )
+
+    original_url = f"http://localhost/media/{key:s}"
+    response = client.get(
+        "/api/v1.0/documents/retrieve-auth/", HTTP_X_ORIGINAL_URL=original_url
+    )
+
+    assert response.status_code == 200
+
+    authorization = response["Authorization"]
+    assert "AWS4-HMAC-SHA256 Credential=" in authorization
+    assert (
+        "SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature="
+        in authorization
+    )
+    assert response["X-Amz-Date"] == timezone.now().strftime("%Y%m%dT%H%M%SZ")
+
+    s3_url = urlparse(settings.AWS_S3_ENDPOINT_URL)
+    file_url = f"{settings.AWS_S3_ENDPOINT_URL:s}/impress-media-storage/{key:s}"
+    response = requests.get(
+        file_url,
+        headers={
+            "authorization": authorization,
+            "x-amz-date": response["x-amz-date"],
+            "x-amz-content-sha256": response["x-amz-content-sha256"],
+            "Host": f"{s3_url.hostname:s}:{s3_url.port:d}",
+        },
+        timeout=1,
+    )
+    assert response.content.decode("utf-8") == "my prose"

--- a/src/backend/core/tests/test_models_documents.py
+++ b/src/backend/core/tests/test_models_documents.py
@@ -63,10 +63,11 @@ def test_models_documents_get_abilities_anonymous_public():
     abilities = document.get_abilities(AnonymousUser())
     assert abilities == {
         "destroy": False,
-        "retrieve": True,
-        "update": False,
+        "attachment_upload": False,
         "manage_accesses": False,
         "partial_update": False,
+        "retrieve": True,
+        "update": False,
         "versions_destroy": False,
         "versions_list": False,
         "versions_retrieve": False,
@@ -79,10 +80,11 @@ def test_models_documents_get_abilities_anonymous_not_public():
     abilities = document.get_abilities(AnonymousUser())
     assert abilities == {
         "destroy": False,
-        "retrieve": False,
-        "update": False,
+        "attachment_upload": False,
         "manage_accesses": False,
         "partial_update": False,
+        "retrieve": False,
+        "update": False,
         "versions_destroy": False,
         "versions_list": False,
         "versions_retrieve": False,
@@ -95,10 +97,11 @@ def test_models_documents_get_abilities_authenticated_unrelated_public():
     abilities = document.get_abilities(factories.UserFactory())
     assert abilities == {
         "destroy": False,
-        "retrieve": True,
-        "update": False,
+        "attachment_upload": False,
         "manage_accesses": False,
         "partial_update": False,
+        "retrieve": True,
+        "update": False,
         "versions_destroy": False,
         "versions_list": False,
         "versions_retrieve": False,
@@ -111,10 +114,11 @@ def test_models_documents_get_abilities_authenticated_unrelated_not_public():
     abilities = document.get_abilities(factories.UserFactory())
     assert abilities == {
         "destroy": False,
-        "retrieve": False,
-        "update": False,
+        "attachment_upload": False,
         "manage_accesses": False,
         "partial_update": False,
+        "retrieve": False,
+        "update": False,
         "versions_destroy": False,
         "versions_list": False,
         "versions_retrieve": False,
@@ -128,10 +132,11 @@ def test_models_documents_get_abilities_owner():
     abilities = access.document.get_abilities(access.user)
     assert abilities == {
         "destroy": True,
-        "retrieve": True,
-        "update": True,
+        "attachment_upload": True,
         "manage_accesses": True,
         "partial_update": True,
+        "retrieve": True,
+        "update": True,
         "versions_destroy": True,
         "versions_list": True,
         "versions_retrieve": True,
@@ -144,10 +149,11 @@ def test_models_documents_get_abilities_administrator():
     abilities = access.document.get_abilities(access.user)
     assert abilities == {
         "destroy": False,
-        "retrieve": True,
-        "update": True,
+        "attachment_upload": True,
         "manage_accesses": True,
         "partial_update": True,
+        "retrieve": True,
+        "update": True,
         "versions_destroy": True,
         "versions_list": True,
         "versions_retrieve": True,
@@ -163,10 +169,11 @@ def test_models_documents_get_abilities_editor_user(django_assert_num_queries):
 
     assert abilities == {
         "destroy": False,
-        "retrieve": True,
-        "update": True,
+        "attachment_upload": True,
         "manage_accesses": False,
         "partial_update": True,
+        "retrieve": True,
+        "update": True,
         "versions_destroy": False,
         "versions_list": True,
         "versions_retrieve": True,
@@ -182,10 +189,11 @@ def test_models_documents_get_abilities_reader_user(django_assert_num_queries):
 
     assert abilities == {
         "destroy": False,
-        "retrieve": True,
-        "update": False,
+        "attachment_upload": False,
         "manage_accesses": False,
         "partial_update": False,
+        "retrieve": True,
+        "update": False,
         "versions_destroy": False,
         "versions_list": True,
         "versions_retrieve": True,
@@ -202,10 +210,11 @@ def test_models_documents_get_abilities_preset_role(django_assert_num_queries):
 
     assert abilities == {
         "destroy": False,
-        "retrieve": True,
-        "update": False,
+        "attachment_upload": False,
         "manage_accesses": False,
         "partial_update": False,
+        "retrieve": True,
+        "update": False,
         "versions_destroy": False,
         "versions_list": True,
         "versions_retrieve": True,
@@ -217,7 +226,7 @@ def test_models_documents_get_versions_slice(settings):
     The "get_versions_slice" method should allow navigating all versions of
     the document with pagination.
     """
-    settings.S3_VERSIONS_PAGE_SIZE = 4
+    settings.DOCUMENT_VERSIONS_PAGE_SIZE = 4
 
     # Create a document with 7 versions
     document = factories.DocumentFactory()

--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -138,7 +138,24 @@ class Base(Configuration):
         environ_prefix=None,
     )
 
-    S3_VERSIONS_PAGE_SIZE = 50
+    # Document images
+    DOCUMENT_IMAGE_MAX_SIZE = values.Value(
+        10 * (2**20),  # 10MB
+        environ_name="DOCUMENT_IMAGE_MAX_SIZE",
+        environ_prefix=None,
+    )
+    DOCUMENT_IMAGE_ALLOWED_MIME_TYPES = [
+        "image/bmp",
+        "image/gif",
+        "image/jpeg",
+        "image/png",
+        "image/svg+xml",
+        "image/tiff",
+        "image/webp",
+    ]
+
+    # Document versions
+    DOCUMENT_VERSIONS_PAGE_SIZE = 50
 
     # Internationalization
     # https://docs.djangoproject.com/en/3.1/topics/i18n/

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "django-parler==2.3",
     "redis==5.0.8",
     "django-redis==5.4.0",
-    "django-storages[s3]==1.14.2",
+    "django-storages[s3]==1.14.4",
     "django-timezone-field>=5.1",
     "django==5.0.8",
     "djangorestframework==3.15.2",

--- a/src/helm/env.d/dev/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.impress.yaml.gotmpl
@@ -103,3 +103,17 @@ ingressWS:
 ingressAdmin:
   enabled: true
   host: impress.127.0.0.1.nip.io
+
+ingressMedia:
+  enabled: true
+  host: impress.127.0.0.1.nip.io
+
+  annotations:
+    nginx.ingress.kubernetes.io/auth-url: https://impress.127.0.0.1.nip.io/api/v1.0/documents/retrieve-auth/
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization, X-Amz-Date, X-Amz-Content-SHA256"
+    nginx.ingress.kubernetes.io/upstream-vhost: minio.impress.svc.cluster.local:9000
+    nginx.ingress.kubernetes.io/rewrite-target: /impress-media-storage/$1
+
+serviceMedia:
+  host: minio.impress.svc.cluster.local
+  port: 9000

--- a/src/helm/env.d/preprod/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/preprod/values.impress.yaml.gotmpl
@@ -154,3 +154,24 @@ ingressAdmin:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/auth-signin: https://oauth2-proxy-preprod.beta.numerique.gouv.fr/oauth2/start
     nginx.ingress.kubernetes.io/auth-url: https://oauth2-proxy-preprod.beta.numerique.gouv.fr/oauth2/auth
+
+ingressMedia:
+  enabled: true
+  host: impress-preprod.beta.numerique.gouv.fr
+
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/auth-url: https://impress-preprod.beta.numerique.gouv.fr/api/v1.0/documents/retrieve-auth/
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization, X-Amz-Date, X-Amz-Content-SHA256"
+    nginx.ingress.kubernetes.io/upstream-vhost:
+      secretKeyRef:
+        name: impress-media-storage.bucket.libre.sh
+        key: url
+    nginx.ingress.kubernetes.io/rewrite-target: /impress-media-storage/$1
+
+serviceMedia:
+  host:
+    secretKeyRef:
+      name: impress-media-storage.bucket.libre.sh
+      key: url
+  port: 9000

--- a/src/helm/env.d/production/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/production/values.impress.yaml.gotmpl
@@ -154,3 +154,24 @@ ingressAdmin:
     cert-manager.io/cluster-issuer: letsencrypt
     nginx.ingress.kubernetes.io/auth-signin: https://oauth2-proxy.beta.numerique.gouv.fr/oauth2/start
     nginx.ingress.kubernetes.io/auth-url: https://oauth2-proxy.beta.numerique.gouv.fr/oauth2/auth
+
+ingressMedia:
+  enabled: true
+  host: docs.numerique.gouv.fr
+
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/auth-url: https://docs.numerique.gouv.fr/api/v1.0/documents/retrieve-auth/
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization, X-Amz-Date, X-Amz-Content-SHA256"
+    nginx.ingress.kubernetes.io/upstream-vhost:
+      secretKeyRef:
+        name: impress-media-storage.bucket.libre.sh
+        key: url
+    nginx.ingress.kubernetes.io/rewrite-target: /impress-media-storage/$1
+
+serviceMedia:
+  host:
+    secretKeyRef:
+      name: impress-media-storage.bucket.libre.sh
+      key: url
+  port: 9000

--- a/src/helm/env.d/staging/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/staging/values.impress.yaml.gotmpl
@@ -154,3 +154,24 @@ ingressAdmin:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/auth-signin: https://oauth2-proxy-preprod.beta.numerique.gouv.fr/oauth2/start
     nginx.ingress.kubernetes.io/auth-url: https://oauth2-proxy-preprod.beta.numerique.gouv.fr/oauth2/auth
+
+ingressMedia:
+  enabled: true
+  host: impress-staging.beta.numerique.gouv.fr
+
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/auth-url: https://impress-staging.beta.numerique.gouv.fr/api/v1.0/documents/retrieve-auth/
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization, X-Amz-Date, X-Amz-Content-SHA256"
+    nginx.ingress.kubernetes.io/upstream-vhost:
+      secretKeyRef:
+        name: impress-media-storage.bucket.libre.sh
+        key: url
+    nginx.ingress.kubernetes.io/rewrite-target: /impress-media-storage/$1
+
+serviceMedia:
+  host:
+    secretKeyRef:
+      name: impress-media-storage.bucket.libre.sh
+      key: url
+  port: 9000

--- a/src/helm/impress/templates/ingress_media.yaml
+++ b/src/helm/impress/templates/ingress_media.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.ingressMedia.enabled -}}
+{{- $fullName := include "impress.fullname" . -}}
+{{- if and .Values.ingressMedia.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingressMedia.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingressMedia.annotations "kubernetes.io/ingress.class" .Values.ingressMedia.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-media
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "impress.labels" . | nindent 4 }}
+  {{- with .Values.ingressMedia.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingressMedia.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingressMedia.className }}
+  {{- end }}
+  {{- if .Values.ingressMedia.tls.enabled }}
+  tls:
+    {{- if .Values.ingressMedia.host }}
+    - secretName: {{ $fullName }}-tls
+      hosts:
+        - {{ .Values.ingressMedia.host | quote }}
+    {{- end }}
+    {{- range .Values.ingressMedia.tls.additional }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if .Values.ingressMedia.host }}
+    - host: {{ .Values.ingressMedia.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingressMedia.path | quote }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}-media
+                port:
+                  number: {{ .Values.serviceMedia.port }}
+              {{- else }}
+              serviceName: {{ $fullName }}-media
+              servicePort: {{ .Values.serviceMedia.port }}
+            {{- end }}
+    {{- end }}
+    {{- range .Values.ingressMedia.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $.Values.ingressMedia.path | quote }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}-media
+                port:
+                  number: {{ .Values.serviceMedia.port }}
+              {{- else }}
+              serviceName: {{ $fullName }}-media
+              servicePort: {{ .Values.serviceMedia.port }}
+            {{- end }}
+    {{- end }}
+{{- end }}

--- a/src/helm/impress/templates/media_svc.yaml
+++ b/src/helm/impress/templates/media_svc.yaml
@@ -1,0 +1,14 @@
+{{- $fullName := include "impress.fullname" . -}}
+{{- $component := "media" -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-media
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "impress.common.labels" (list . $component) | nindent 4 }}
+  annotations:
+    {{- toYaml $.Values.serviceMedia.annotations | nindent 4 }}
+spec:
+  type: ExternalName
+  externalName: {{ $.Values.serviceMedia.host }}

--- a/src/helm/impress/values.yaml
+++ b/src/helm/impress/values.yaml
@@ -37,7 +37,7 @@ ingress:
   ## @param ingress.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
-  ## @param ingress.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingress.tls.enabled Wether to enable TLS for the Ingress
   ## @skip ingress.tls.additional
   ## @extra ingress.tls.additional[].secretName Secret name for additional TLS config
   ## @extra ingress.tls.additional[].hosts[] Hosts for additional TLS config
@@ -60,7 +60,7 @@ ingressWS:
   ## @param ingress.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
-  ## @param ingressWS.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressWS.tls.enabled Wether to enable TLS for the Ingress
   ## @skip ingressWS.tls.additional
   ## @extra ingressWS.tls.additional[].secretName Secret name for additional TLS config
   ## @extra ingressWS.tls.additional[].hosts[] Hosts for additional TLS config
@@ -87,13 +87,43 @@ ingressAdmin:
   ## @param ingressAdmin.hosts Additional host to configure for the Ingress
   hosts: [ ]
   #  - chart-example.local
-  ## @param ingressAdmin.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressAdmin.tls.enabled Wether to enable TLS for the Ingress
   ## @skip ingressAdmin.tls.additional
   ## @extra ingressAdmin.tls.additional[].secretName Secret name for additional TLS config
   ## @extra ingressAdmin.tls.additional[].hosts[] Hosts for additional TLS config
   tls:
     enabled: true
     additional: []
+
+## @param ingressMedia.enabled whether to enable the Ingress or not
+## @param ingressMedia.className IngressClass to use for the Ingress
+## @param ingressMedia.host Host for the Ingress
+## @param ingressMedia.path Path to use for the Ingress
+ingressMedia:
+  enabled: false
+  className: null
+  host: impress.example.com
+  path: /media/(.*)
+  ## @param ingressMedia.hosts Additional host to configure for the Ingress
+  hosts: [ ]
+  #  - chart-example.local
+  ## @param ingressMedia.tls.enabled Wether to enable TLS for the Ingress
+  ## @skip ingressMedia.tls.additional
+  ## @extra ingressMedia.tls.additional[].secretName Secret name for additional TLS config
+  ## @extra ingressMedia.tls.additional[].hosts[] Hosts for additional TLS config
+  tls:
+    enabled: true
+    additional: []
+
+  annotations:
+    nginx.ingress.kubernetes.io/auth-url: https://impress.example.com/api/v1.0/documents/retrieve-auth/
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization, X-Amz-Date, X-Amz-Content-SHA256"
+    nginx.ingress.kubernetes.io/upstream-vhost: minio.impress.svc.cluster.local:9000
+
+serviceMedia:
+  host: minio.impress.svc.cluster.local
+  port: 9000
+  annotations: {}
 
 
 ## @section backend


### PR DESCRIPTION
## Purpose

We want to be able to attach images to a document. Strict access control should be applied on all images of a document.

## Proposal

- upload images to a folder next to each document's content file : `{document.id}/attachments/{image_filename}
- allow downloading attachment images from object storage via the nginx ingress. Access control is done thanks to nginx subrequests.
- Update the helm chart to add the new media url with access control delegated to Django