### PR TITLE
🔥(frontend) remove markdown button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,18 @@ and this project adheres to
 
 ## [Unreleased]
 
-# Added
+## Added
 
 - ✨Add image attachments with access control
-- ✨(frontend) Upload image to a document
+- ✨(frontend) Upload image to a document #211
+
+## Changed
+
+- 🔥(frontend) hide markdown button if not text #213
+
+## Removed
+
+- 🔥(frontend) remove saving modal #213
 
 
 ## [1.2.1] - 2024-08-23

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-editor.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-editor.spec.ts
@@ -106,10 +106,6 @@ test.describe('Doc Editor', () => {
       nthRow: 2,
     });
 
-    await expect(
-      page.getByText(`Your document "${doc}" has been saved.`),
-    ).toBeVisible();
-
     await expect(page.locator('h2').getByText(secondDoc)).toBeVisible();
 
     await goToGridDoc(page, {

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteToolbar.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteToolbar.tsx
@@ -11,9 +11,10 @@ import {
   UnnestBlockButton,
   useBlockNoteEditor,
   useComponentsContext,
+  useSelectedBlocks,
 } from '@blocknote/react';
 import { forEach, isArray } from 'lodash';
-import React from 'react';
+import React, { useMemo } from 'react';
 
 export const BlockNoteToolbar = () => {
   return (
@@ -91,6 +92,7 @@ const recursiveContent = (content: Block[], base: string = '') => {
 export function MarkdownButton() {
   const editor = useBlockNoteEditor();
   const Components = useComponentsContext();
+  const selectedBlocks = useSelectedBlocks(editor);
 
   const handleConvertMarkdown = () => {
     const blocks = editor.getSelection()?.blocks;
@@ -114,7 +116,11 @@ export function MarkdownButton() {
     });
   };
 
-  if (!Components) {
+  const show = useMemo(() => {
+    return !!selectedBlocks.find((block) => block.content !== undefined);
+  }, [selectedBlocks]);
+
+  if (!show || !editor.isEditable || !Components) {
     return null;
   }
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/hook/useSaveDoc.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/hook/useSaveDoc.tsx
@@ -1,7 +1,5 @@
-import { VariantType, useToastProvider } from '@openfun/cunningham-react';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import * as Y from 'yjs';
 
 import { useUpdateDoc } from '@/features/docs/doc-management/';
@@ -11,22 +9,9 @@ import { useDocStore } from '../stores';
 import { toBase64 } from '../utils';
 
 const useSaveDoc = (docId: string, doc: Y.Doc, canSave: boolean) => {
-  const { toast } = useToastProvider();
-  const { t } = useTranslation();
   const { forceSave, setForceSave } = useDocStore();
 
   const { mutate: updateDoc } = useUpdateDoc({
-    onSuccess: (data) => {
-      toast(
-        t('Your document "{{docTitle}}" has been saved.', {
-          docTitle: data.title,
-        }),
-        VariantType.SUCCESS,
-        {
-          duration: 1500,
-        },
-      );
-    },
     listInvalideQueries: [KEY_LIST_DOC_VERSIONS],
   });
   const [initialDoc, setInitialDoc] = useState<string>(


### PR DESCRIPTION
## Purpose

🔥(frontend) remove saving modal

The saving toast are removed.
Users were complaining about the toast that was shown when saving a document.

----

🔥(frontend) hide markdown button if not text

If we are selected a block that is not a text block, we hide the markdown button.


## Proposal

- [x] 🔥(frontend) remove saving modal
- [x] 🔥(frontend) hide markdown button if not text
