### PR TITLE
🔧(compose) stop forcing platform for Keycloak PostgreSQL image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to
 
 - 🐛 Fix emoticon in pdf export #225
 - 🐛 Fix collaboration on document #226
+- 🐛 (docker) Fix compatibility with mac #230
 
 ## Removed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,7 +172,6 @@ services:
 
   kc_postgresql:
     image: postgres:14.3
-    platform: linux/amd64
     ports:
       - "5433:5432"
     env_file:


### PR DESCRIPTION
## Purpose

Forcing `platform: linux/amd64` for the PostgreSQL image causes compatibility issues and performance
degradation on Mac ARM chips (M1/M2).
Removing the platform specification allows Docker
to select the appropriate architecture automatically, ensuring better performance and compatibility.
