### PR TITLE
🐛(frontend) meta title rerender issue

### DIFF
--- a/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
+++ b/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
@@ -36,7 +36,9 @@ const DocPage = ({ id }: DocProps) => {
 
   useEffect(() => {
     if (doc?.title) {
-      document.title = `${doc.title} - Docs`;
+      setTimeout(() => {
+        document.title = `${doc.title} - Docs`;
+      }, 100);
     }
   }, [doc?.title]);
 


### PR DESCRIPTION
## Purpose

The meta title is not displayed when we come back to a page from the dynamic router. The code seems to
compute to quickly so we need to add a delay to the meta title computation.

