### PR TITLE
🧑‍💻(makefile) add build frontend dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to
 ## Fixed
 
 - 🐛 Fix forcing ID when creating a document via API endpoint #234
+- 🐛 Rebuild frontend dev container from makefile #248
 
 
 ## [1.3.0] - 2024-09-05

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ bootstrap: \
 # -- Docker/compose
 build: ## build the app-dev container
 	@$(COMPOSE) build app-dev --no-cache
+	@$(COMPOSE) build frontend-dev --no-cache
 .PHONY: build
 
 down: ## stop and remove containers, networks, images, and volumes


### PR DESCRIPTION
## Purpose

docker build frontend dev was lacking.
If dependencies were updated, the change were
not reflected in the frontend container.



