### PR TITLE
✅(backend) fix flaky tests

### DIFF
--- a/.github/workflows/impress.yml
+++ b/.github/workflows/impress.yml
@@ -168,7 +168,7 @@ jobs:
           path: "src/backend/core/templates/mail"
           key: mail-templates-${{ hashFiles('src/mail/mjml') }}
 
-      - name: Start Minio
+      - name: Start MinIO
         run: |
           docker pull minio/minio
           docker run -d --name minio \
@@ -177,6 +177,15 @@ jobs:
             -e "MINIO_SECRET_KEY=password" \
             -v /data/media:/data \
             minio/minio server --console-address :9001 /data
+
+      # Tool to wait for a service to be ready
+      - name: Install Dockerize
+        run: |
+          curl -sSL https://github.com/jwilder/dockerize/releases/download/v0.8.0/dockerize-linux-amd64-v0.8.0.tar.gz | sudo tar -C /usr/local/bin -xzv
+
+      - name: Wait for MinIO to be ready
+        run: |
+          dockerize -wait tcp://localhost:9000 -timeout 10s
 
       - name: Configure MinIO
         run: |

--- a/src/backend/core/tests/test_models_templates.py
+++ b/src/backend/core/tests/test_models_templates.py
@@ -3,6 +3,7 @@ Unit tests for the Template model
 """
 
 import os
+import time
 from unittest import mock
 
 from django.contrib.auth.models import AnonymousUser
@@ -203,7 +204,7 @@ def test_models_templates__generate_word():
     "pypandoc.convert_text",
     side_effect=RuntimeError("Conversion failed"),
 )
-def test_models_templates__generate_word__raise_error(_mock_send_mail):
+def test_models_templates__generate_word__raise_error(_mock_pypandoc):
     """
     Generate word document and assert no tmp files are left in /tmp folder
     even when the conversion fails.
@@ -214,4 +215,5 @@ def test_models_templates__generate_word__raise_error(_mock_send_mail):
         template.generate_word("<p>Test body</p>", {})
     except RuntimeError as e:
         assert str(e) == "Conversion failed"
+        time.sleep(0.5)
         assert len([f for f in os.listdir("/tmp") if f.startswith("docx_")]) == 0


### PR DESCRIPTION
## Purpose

- ✅(backend) fix flaky test on tmp file: 
It seems to have a race condition, sometimes the tmp file is not deleted before the test assertion.  We let the test sleep for 0.5 second before the assertion.


- ✅(CI) fix flaky test on Minio initialized:
Minio server need to be initialized before running the job to configure Minio.
We add a delay to wait for Minio server to be ready.