### PR TITLE
🛂(frontend) redirect to the OIDC when private doc and unauthentified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ and this project adheres to
 
 ## Fixed
 
-- 🐛 (backend) gitlab oicd userinfo endpoint #232
-- ♻️ (backend) getting list of document versions available for a user #258
+- 🐛(backend) gitlab oicd userinfo endpoint #232
+- 🛂(frontend) redirect to the OIDC when private doc and unauthentified #292
+- ♻️(backend) getting list of document versions available for a user #258
 
 ## [1.4.0] - 2024-09-17
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/common.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/common.ts
@@ -1,10 +1,6 @@
 import { Page, expect } from '@playwright/test';
 
 export const keyCloakSignIn = async (page: Page, browserName: string) => {
-  const title = await page.locator('h1').first().textContent({
-    timeout: 5000,
-  });
-
   const login = `user-e2e-${browserName}`;
   const password = `password-e2e-${browserName}`;
 
@@ -12,7 +8,7 @@ export const keyCloakSignIn = async (page: Page, browserName: string) => {
     await page.getByRole('textbox', { name: 'password' }).fill(password);
 
     await page.click('input[type="submit"]', { force: true });
-  } else if (title?.includes('Sign in to your account')) {
+  } else {
     await page.getByRole('textbox', { name: 'username' }).fill(login);
 
     await page.getByRole('textbox', { name: 'password' }).fill(password);

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-routing.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-routing.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { keyCloakSignIn } from './common';
+import { keyCloakSignIn, mockedDocument } from './common';
 
 test.describe('Doc Routing', () => {
   test.beforeEach(async ({ page }) => {
@@ -43,9 +43,12 @@ test.describe('Doc Routing: Not loggued', () => {
     page,
     browserName,
   }) => {
+    await mockedDocument(page, { link_reach: 'public' });
     await page.goto('/docs/mocked-document-id/');
+    await expect(page.locator('h2').getByText('Mocked document')).toBeVisible();
+    await page.getByRole('button', { name: 'Login' }).click();
     await keyCloakSignIn(page, browserName);
-    await expect(page).toHaveURL(/\/docs\/mocked-document-id\/$/);
+    await expect(page.locator('h2').getByText('Mocked document')).toBeVisible();
   });
 
   test('The homepage redirects to login.', async ({ page }) => {

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-visibility.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-visibility.spec.ts
@@ -93,4 +93,31 @@ test.describe('Doc Visibility: Not loggued', () => {
 
     await expect(page.locator('h2').getByText(docTitle)).toBeVisible();
   });
+
+  test('A private doc redirect to the OIDC when not authentified.', async ({
+    page,
+    browserName,
+  }) => {
+    test.slow();
+    await page.goto('/');
+    await keyCloakSignIn(page, browserName);
+
+    const [docTitle] = await createDoc(page, 'My private doc', browserName, 1);
+
+    await expect(page.locator('h2').getByText(docTitle)).toBeVisible();
+
+    const urlDoc = page.url();
+
+    await page
+      .getByRole('button', {
+        name: 'Logout',
+      })
+      .click();
+
+    await expect(page.getByRole('textbox', { name: 'password' })).toBeVisible();
+
+    await page.goto(urlDoc);
+
+    await expect(page.getByRole('textbox', { name: 'password' })).toBeVisible();
+  });
 });

--- a/src/frontend/apps/impress/src/core/AppProvider.tsx
+++ b/src/frontend/apps/impress/src/core/AppProvider.tsx
@@ -17,6 +17,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 1000 * 60 * 3,
+      retry: 1,
     },
   },
 });

--- a/src/frontend/apps/impress/src/core/auth/Auth.tsx
+++ b/src/frontend/apps/impress/src/core/auth/Auth.tsx
@@ -17,8 +17,9 @@ import { useAuthStore } from './useAuthStore';
 const regexpUrlsAuth = [/\/docs\/$/g, /^\/$/g];
 
 export const Auth = ({ children }: PropsWithChildren) => {
-  const { initAuth, initiated, authenticated, login } = useAuthStore();
-  const { asPath } = useRouter();
+  const { initAuth, initiated, authenticated, login, getAuthUrl } =
+    useAuthStore();
+  const { asPath, replace } = useRouter();
 
   const [pathAllowed, setPathAllowed] = useState<boolean>(
     !regexpUrlsAuth.some((regexp) => !!asPath.match(regexp)),
@@ -40,6 +41,18 @@ export const Auth = ({ children }: PropsWithChildren) => {
 
     login();
   }, [authenticated, pathAllowed, login, initiated]);
+
+  // Redirect to the path before login
+  useEffect(() => {
+    if (!authenticated) {
+      return;
+    }
+
+    const authUrl = getAuthUrl();
+    if (authUrl) {
+      void replace(authUrl);
+    }
+  }, [authenticated, getAuthUrl, replace]);
 
   if ((!initiated && pathAllowed) || (!authenticated && !pathAllowed)) {
     return (

--- a/src/frontend/apps/impress/src/core/auth/useAuthStore.tsx
+++ b/src/frontend/apps/impress/src/core/auth/useAuthStore.tsx
@@ -11,6 +11,8 @@ interface AuthStore {
   initAuth: () => void;
   logout: () => void;
   login: () => void;
+  setAuthUrl: (url: string) => void;
+  getAuthUrl: () => string | undefined;
   userData?: User;
 }
 
@@ -20,22 +22,13 @@ const initialState = {
   userData: undefined,
 };
 
-export const useAuthStore = create<AuthStore>((set) => ({
+export const useAuthStore = create<AuthStore>((set, get) => ({
   initiated: initialState.initiated,
   authenticated: initialState.authenticated,
   userData: initialState.userData,
-
   initAuth: () => {
     getMe()
       .then((data: User) => {
-        // If a path is stored in the local storage, we redirect to it
-        const path_auth = localStorage.getItem(PATH_AUTH_LOCAL_STORAGE);
-        if (path_auth) {
-          localStorage.removeItem(PATH_AUTH_LOCAL_STORAGE);
-          window.location.replace(path_auth);
-          return;
-        }
-
         set({ authenticated: true, userData: data });
       })
       .catch(() => {})
@@ -44,15 +37,26 @@ export const useAuthStore = create<AuthStore>((set) => ({
       });
   },
   login: () => {
-    // If we try to access a specific page and we are not authenticated
-    // we store the path in the local storage to redirect to it after login
-    if (window.location.pathname !== '/') {
-      localStorage.setItem(PATH_AUTH_LOCAL_STORAGE, window.location.pathname);
-    }
+    get().setAuthUrl(window.location.pathname);
 
     window.location.replace(`${baseApiUrl()}authenticate/`);
   },
   logout: () => {
     window.location.replace(`${baseApiUrl()}logout/`);
+  },
+  // If we try to access a specific page and we are not authenticated
+  // we store the path in the local storage to redirect to it after login
+  setAuthUrl() {
+    if (window.location.pathname !== '/') {
+      localStorage.setItem(PATH_AUTH_LOCAL_STORAGE, window.location.pathname);
+    }
+  },
+  // If a path is stored in the local storage, we return it then remove it
+  getAuthUrl() {
+    const path_auth = localStorage.getItem(PATH_AUTH_LOCAL_STORAGE);
+    if (path_auth) {
+      localStorage.removeItem(PATH_AUTH_LOCAL_STORAGE);
+      return path_auth;
+    }
   },
 }));

--- a/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
+++ b/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 
 import { Box, Text } from '@/components';
 import { TextErrors } from '@/components/TextErrors';
+import { useAuthStore } from '@/core/auth';
 import { DocEditor } from '@/features/docs';
 import { useDoc } from '@/features/docs/doc-management';
 import { MainLayout } from '@/layouts';
@@ -31,6 +32,7 @@ interface DocProps {
 }
 
 const DocPage = ({ id }: DocProps) => {
+  const { authenticated, login } = useAuthStore();
   const { data: docQuery, isError, error } = useDoc({ id });
   const [doc, setDoc] = useState(docQuery);
 
@@ -55,6 +57,11 @@ const DocPage = ({ id }: DocProps) => {
   if (isError && error) {
     if (error.status === 404) {
       navigate.replace(`/404`);
+      return null;
+    }
+
+    if (error.status === 401 && !authenticated) {
+      login();
       return null;
     }
 


### PR DESCRIPTION
## Purpose

When we access a private doc and we are not connected we were getting an error message.
Instead of this error message, we now redirect to the OIDC.

## Proposal

- [x] 🐛(frontend) fix redirection after login
- [x] 🛂(frontend) redirect to the OIDC when private doc


