### PR TITLE
♻️(backend) allow uploading more types of attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to
 
 ## Added
 
+- ✨(backend) allow uploading more types of attachments #309
 - ✨(backend) add name fields to the user synchronized with OIDC #301
 - ✨(ci) add security scan #291
 - ♻️(frontend) Add versions #277

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,14 +65,15 @@ ENV PYTHONUNBUFFERED=1
 
 # Install required system libs
 RUN apk add \
-  gettext \
   cairo \
-  libffi-dev \
-  gdk-pixbuf \
-  pango \
-  pandoc \
-  font-noto-emoji \
+  file \
   font-noto \
+  font-noto-emoji \
+  gettext \
+  gdk-pixbuf \
+  libffi-dev \
+  pandoc \
+  pango \
   shared-mime-info
 
 # Copy entrypoint

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
+import magic
 from rest_framework import exceptions, serializers
 
 from core import models
@@ -219,15 +220,41 @@ class FileUploadSerializer(serializers.Serializer):
                 f"File size exceeds the maximum limit of {max_size:d} MB."
             )
 
-        # Validate file type
-        mime_type, _ = mimetypes.guess_type(file.name)
-        if mime_type not in settings.DOCUMENT_IMAGE_ALLOWED_MIME_TYPES:
-            mime_types = ", ".join(settings.DOCUMENT_IMAGE_ALLOWED_MIME_TYPES)
-            raise serializers.ValidationError(
-                f"File type '{mime_type:s}' is not allowed. Allowed types are: {mime_types:s}"
-            )
+        extension = file.name.rpartition(".")[-1] if "." in file.name else None
+
+        # Read the first few bytes to determine the MIME type accurately
+        mime = magic.Magic(mime=True)
+        magic_mime_type = mime.from_buffer(file.read(1024))
+        file.seek(0)  # Reset file pointer to the beginning after reading
+
+        self.context["is_unsafe"] = (
+            magic_mime_type in settings.DOCUMENT_UNSAFE_MIME_TYPES
+        )
+
+        extension_mime_type, _ = mimetypes.guess_type(file.name)
+
+        # Try guessing a coherent extension from the mimetype
+        if extension_mime_type != magic_mime_type:
+            self.context["is_unsafe"] = True
+
+        guessed_ext = mimetypes.guess_extension(magic_mime_type)
+        # Missing extensions or extensions longer than 5 characters (it's as long as an extension
+        # can be) are replaced by the extension we eventually guessed from mimetype.
+        if (extension is None or len(extension) > 5) and guessed_ext:
+            extension = guessed_ext[1:]
+
+        if extension is None:
+            raise serializers.ValidationError("Could not determine file extension.")
+
+        self.context["expected_extension"] = extension
 
         return file
+
+    def validate(self, attrs):
+        """Override validate to add the computed extension to validated_data."""
+        attrs["expected_extension"] = self.context["expected_extension"]
+        attrs["is_unsafe"] = self.context["is_unsafe"]
+        return attrs
 
 
 class TemplateSerializer(BaseResourceSerializer):

--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -144,14 +144,75 @@ class Base(Configuration):
         environ_name="DOCUMENT_IMAGE_MAX_SIZE",
         environ_prefix=None,
     )
-    DOCUMENT_IMAGE_ALLOWED_MIME_TYPES = [
-        "image/bmp",
-        "image/gif",
-        "image/jpeg",
-        "image/png",
+
+    DOCUMENT_UNSAFE_MIME_TYPES = [
+        # Executable Files
+        "application/x-msdownload",
+        "application/x-bat",
+        "application/x-dosexec",
+        "application/x-sh",
+        "application/x-ms-dos-executable",
+        "application/x-msi",
+        "application/java-archive",
+        "application/octet-stream",
+        # Dynamic Web Pages
+        "application/x-httpd-php",
+        "application/x-asp",
+        "application/x-aspx",
+        "application/jsp",
+        "application/xhtml+xml",
+        "application/x-python-code",
+        "application/x-perl",
+        "text/html",
+        "text/javascript",
+        "text/x-php",
+        # System Files
+        "application/x-msdownload",
+        "application/x-sys",
+        "application/x-drv",
+        "application/cpl",
+        "application/x-apple-diskimage",
+        # Script Files
+        "application/javascript",
+        "application/x-vbscript",
+        "application/x-powershell",
+        "application/x-shellscript",
+        # Compressed/Archive Files
+        "application/zip",
+        "application/x-tar",
+        "application/gzip",
+        "application/x-bzip2",
+        "application/x-7z-compressed",
+        "application/x-rar",
+        "application/x-rar-compressed",
+        "application/x-compress",
+        "application/x-lzma",
+        # Macros in Documents
+        "application/vnd.ms-word",
+        "application/vnd.ms-excel",
+        "application/vnd.ms-powerpoint",
+        "application/vnd.ms-word.document.macroenabled.12",
+        "application/vnd.ms-excel.sheet.macroenabled.12",
+        "application/vnd.ms-powerpoint.presentation.macroenabled.12",
+        # Disk Images & Virtual Disk Files
+        "application/x-iso9660-image",
+        "application/x-vmdk",
+        "application/x-apple-diskimage",
+        "application/x-dmg",
+        # Other Dangerous MIME Types
+        "application/x-ms-application",
+        "application/x-msdownload",
+        "application/x-shockwave-flash",
+        "application/x-silverlight-app",
+        "application/x-java-vm",
+        "application/x-bittorrent",
+        "application/hta",
+        "application/x-csh",
+        "application/x-ksh",
+        "application/x-ms-regedit",
+        "application/x-msdownload",
+        "application/xml",
         "image/svg+xml",
-        "image/tiff",
-        "image/webp",
     ]
 
     # Document versions

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "PyJWT==2.9.0",
     "pypandoc==1.14",
     "python-frontmatter==1.1.0",
+    "python-magic==0.4.27",
     "requests==2.32.3",
     "sentry-sdk==2.16.0",
     "url-normalize==1.4.3",

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
     "dockerflow==2024.4.2",
     "easy_thumbnails==2.10",
     "factory_boy==3.3.1",
-    "freezegun==1.5.1",
     "gunicorn==23.0.0",
     "jsonschema==4.23.0",
     "markdown==3.7",
@@ -69,6 +68,7 @@ dependencies = [
 dev = [
     "django-extensions==3.2.3",
     "drf-spectacular-sidecar==2024.7.1",
+    "freezegun==1.5.1",
     "ipdb==0.13.13",
     "ipython==8.28.0",
     "pyfakefs==5.7.1",


### PR DESCRIPTION
## Purpose

We want to allow users to upload files to a document, not just images. 

## Proposal

We try to enforce coherence between the file extension and the real mime type of its content using magic.

If a file is deemed unsafe, it is still accepted during upload and the information is stored as metadata on the object for display to readers in the frontend.