### PR TITLE
🐛(service-worker) fix circular import problem

### DIFF
--- a/src/frontend/apps/impress/src/features/service-worker/ApiPlugin.ts
+++ b/src/frontend/apps/impress/src/features/service-worker/ApiPlugin.ts
@@ -1,11 +1,7 @@
 import { WorkboxPlugin } from 'workbox-core';
 
-import {
-  Doc,
-  DocsResponse,
-  LinkReach,
-  Role,
-} from '@/features/docs/doc-management';
+import { Doc, DocsResponse } from '@/features/docs/doc-management';
+import { LinkReach, Role } from '@/features/docs/doc-management/types';
 
 import { DBRequest, DocsDB } from './DocsDB';
 import { RequestSerializer } from './RequestSerializer';


### PR DESCRIPTION
## Purpose

When we were installing the service-worker, errors were thrown because of circular imports.
This commit fixes the problem by being more explicit about the imports.


