### PR TITLE
✨(frontend): Added copy-as buttons for HTML and Markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Added
+
+- ✨(frontend) add buttons to copy document to clipboard as HTML/Markdown #300
+
 ## Changed
 
 - ♻️(frontend) More multi theme friendly #325
@@ -17,7 +21,7 @@ and this project adheres to
 
 ## Fixed
 
-🐛(frontend) invalidate queries after removing user #336
+- 🐛(frontend) invalidate queries after removing user #336
 
 
 ## [1.5.1] - 2024-10-10

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-header.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-header.spec.ts
@@ -384,6 +384,81 @@ test.describe('Doc Header', () => {
       }),
     ).toBeHidden();
   });
+
+  test('It checks the copy as Markdown button', async ({
+    page,
+    browserName,
+  }) => {
+    // eslint-disable-next-line playwright/no-skipped-test
+    test.skip(
+      browserName === 'webkit',
+      'navigator.clipboard is not working with webkit and playwright',
+    );
+
+    // create page and navigate to it
+    await page
+      .getByRole('button', {
+        name: 'Create a new document',
+      })
+      .click();
+
+    // Add dummy content to the doc
+    const editor = page.locator('.ProseMirror');
+    const docFirstBlock = editor.locator('.bn-block-content').first();
+    await docFirstBlock.click();
+    await page.keyboard.type('# Hello World', { delay: 100 });
+    const docFirstBlockContent = docFirstBlock.locator('h1');
+    await expect(docFirstBlockContent).toHaveText('Hello World');
+
+    // Copy content to clipboard
+    await page.getByLabel('Open the document options').click();
+    await page.getByRole('button', { name: 'Copy as Markdown' }).click();
+    await expect(page.getByText('Copied to clipboard')).toBeVisible();
+
+    // Test that clipboard is in Markdown format
+    const handle = await page.evaluateHandle(() =>
+      navigator.clipboard.readText(),
+    );
+    const clipboardContent = await handle.jsonValue();
+    expect(clipboardContent.trim()).toBe('# Hello World');
+  });
+
+  test('It checks the copy as HTML button', async ({ page, browserName }) => {
+    // eslint-disable-next-line playwright/no-skipped-test
+    test.skip(
+      browserName === 'webkit',
+      'navigator.clipboard is not working with webkit and playwright',
+    );
+
+    // create page and navigate to it
+    await page
+      .getByRole('button', {
+        name: 'Create a new document',
+      })
+      .click();
+
+    // Add dummy content to the doc
+    const editor = page.locator('.ProseMirror');
+    const docFirstBlock = editor.locator('.bn-block-content').first();
+    await docFirstBlock.click();
+    await page.keyboard.type('# Hello World', { delay: 100 });
+    const docFirstBlockContent = docFirstBlock.locator('h1');
+    await expect(docFirstBlockContent).toHaveText('Hello World');
+
+    // Copy content to clipboard
+    await page.getByLabel('Open the document options').click();
+    await page.getByRole('button', { name: 'Copy as HTML' }).click();
+    await expect(page.getByText('Copied to clipboard')).toBeVisible();
+
+    // Test that clipboard is in HTML format
+    const handle = await page.evaluateHandle(() =>
+      navigator.clipboard.readText(),
+    );
+    const clipboardContent = await handle.jsonValue();
+    expect(clipboardContent.trim()).toBe(
+      `<h1 data-level="1">Hello World</h1><p></p>`,
+    );
+  });
 });
 
 test.describe('Documents Header mobile', () => {


### PR DESCRIPTION
Closes #300 
