### PR TITLE
🐛(backend) Fixing docker-compose.yml to make nginx depend on app-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to
 
 - 🐛(frontend) invalidate queries after removing user #336
 - 🐛(backend) Fix dysfunctional permissions on document create #329
+- 🐛(backend) fix nginx docker container #340
 
 ## [1.5.1] - 2024-10-10
 

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ logs: ## display app-dev logs (follow mode)
 
 run: ## start the wsgi (production) and development server
 	@$(COMPOSE) up --force-recreate -d celery-dev
+	@$(COMPOSE) up --force-recreate -d nginx
 	@$(COMPOSE) up --force-recreate -d y-provider
 	@echo "Wait for postgresql to be up..."
 	@$(WAIT_DB)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,6 @@ services:
         - mailcatcher
         - redis
         - createbuckets
-        - nginx
   
   celery-dev:
     user: ${DOCKER_USER:-1000}
@@ -118,6 +117,7 @@ services:
       - ./docker/files/etc/nginx/conf.d:/etc/nginx/conf.d:ro
     depends_on:
       - keycloak
+      - app-dev
 
   frontend-dev:
     user: "${DOCKER_USER:-1000}"


### PR DESCRIPTION
## Purpose

This will fix [issue #339](https://github.com/numerique-gouv/impress/issues/339), ensuring that nginx starts only after app-dev is up and running, preventing startup failures.


## Proposal

To address this, the following steps will be taken:

- Update docker-compose.yml to include a dependency on nginx for app-dev.
- Verify that the dependency order resolves the issue with nginx startup.

Description...
 - [x] Modify docker-compose.yml to add depends_on: app-dev for the nginx service.
 - [x] Test the configuration to ensure nginx waits for app-dev to start.