### PR TITLE
🐛(frontend) avoid documents indexing in search engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to
 - 🐛(i18n) same frontend and backend language using shared cookies #365
 - 🐛(frontend) add default toolbar buttons #355
 - 🐛(frontend) throttle error correctly display #378
+- 🐛(frontend) (frontend) avoid documents indexing in search engine #372
 
 ## Removed
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-routing.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-routing.spec.ts
@@ -7,6 +7,22 @@ test.describe('Doc Routing', () => {
     await page.goto('/');
   });
 
+  test('Check the presence of the meta tag noindex', async ({ page }) => {
+    const buttonCreateHomepage = page.getByRole('button', {
+      name: 'Create a new document',
+    });
+
+    await expect(buttonCreateHomepage).toBeVisible();
+    await buttonCreateHomepage.click();
+    await expect(
+      page.getByRole('button', {
+        name: 'Share',
+      }),
+    ).toBeVisible();
+    const metaDescription = page.locator('meta[name="robots"]');
+    await expect(metaDescription).toHaveAttribute('content', 'noindex');
+  });
+
   test('checks alias docs url with homepage', async ({ page }) => {
     await expect(page).toHaveURL('/');
 

--- a/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
+++ b/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
@@ -1,4 +1,5 @@
 import { Loader } from '@openfun/cunningham-react';
+import Head from 'next/head';
 import { useRouter as useNavigate } from 'next/navigation';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
@@ -21,9 +22,14 @@ export function DocLayout() {
   }
 
   return (
-    <MainLayout withoutFooter>
-      <DocPage id={id} />
-    </MainLayout>
+    <>
+      <Head>
+        <meta name="robots" content="noindex" />
+      </Head>
+      <MainLayout withoutFooter>
+        <DocPage id={id} />
+      </MainLayout>
+    </>
   );
 }
 


### PR DESCRIPTION
## Purpose

Some documents are available publicly (without being logged) and may thus end-up being indexed by search engine.

## Proposal

Add a meta tag in the <head> section of the page (See https://developers.google.com/search/docs/crawling-indexing/block-indexing for more information):
```
<meta name="robots" content="noindex">
```
