### PR TITLE
🔖(minor) release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.7.0] - 2024-10-24
+
 ## Added
 
 - 📝Contributing.md #352
-- 🌐(frontend) add localization to editor #268
+- 🌐(frontend) add localization to editor #368
 - ✨Public and restricted doc editable #357
 - ✨(frontend) Add full name if available #380
 - ✨(backend) Add view accesses ability #376
@@ -20,6 +22,7 @@ and this project adheres to
 ## Changed
 
 - ♻️(frontend) list accesses if user has abilities #376
+- ♻️(frontend) avoid documents indexing in search engine #372
 - 👔(backend) doc restricted by default #388
 
 ## Fixed
@@ -28,7 +31,6 @@ and this project adheres to
 - 🐛(i18n) same frontend and backend language using shared cookies #365
 - 🐛(frontend) add default toolbar buttons #355
 - 🐛(frontend) throttle error correctly display #378
-- 🐛(frontend) (frontend) avoid documents indexing in search engine #372
 
 ## Removed
 
@@ -236,7 +238,8 @@ and this project adheres to
 - 🚀 Impress, project to manage your documents easily and collaboratively.
 
 
-[unreleased]: https://github.com/numerique-gouv/impress/compare/v1.6.0...main
+[unreleased]: https://github.com/numerique-gouv/impress/compare/v1.7.0...main
+[v1.7.0]: https://github.com/numerique-gouv/impress/releases/v1.7.0
 [v1.6.0]: https://github.com/numerique-gouv/impress/releases/v1.6.0
 [1.5.1]: https://github.com/numerique-gouv/impress/releases/v1.5.1
 [1.5.0]: https://github.com/numerique-gouv/impress/releases/v1.5.0

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "impress"
-version = "1.6.0"
+version = "1.7.0"
 authors = [{ "name" = "DINUM", "email" = "dev@mail.numerique.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/frontend/apps/e2e/package.json
+++ b/src/frontend/apps/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-e2e",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "scripts": {
     "lint": "eslint . --ext .ts",

--- a/src/frontend/apps/impress/package.json
+++ b/src/frontend/apps/impress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-impress",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "impress",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "workspaces": {
     "packages": [

--- a/src/frontend/packages/eslint-config-impress/package.json
+++ b/src/frontend/packages/eslint-config-impress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-impress",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "license": "MIT",
   "scripts": {
     "lint": "eslint --ext .js ."

--- a/src/frontend/packages/i18n/package.json
+++ b/src/frontend/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packages-i18n",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "scripts": {
     "extract-translation": "yarn extract-translation:impress",

--- a/src/frontend/servers/y-provider/package.json
+++ b/src/frontend/servers/y-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server-y-provider",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Y.js provider for docs",
   "repository": "https://github.com/numerique-gouv/impress",
   "license": "MIT",

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Added

- 📝Contributing.md #352
- 🌐(frontend) add localization to editor #368
- ✨Public and restricted doc editable #357
- ✨(frontend) Add full name if available #380
- ✨(backend) Add view accesses ability #376

## Changed

- ♻️(frontend) list accesses if user has abilities #376
- ♻️(frontend) avoid documents indexing in search engine #372
- 👔(backend) doc restricted by default #388

## Fixed

- 🐛(backend) require right to manage document accesses to see invitations #369
- 🐛(i18n) same frontend and backend language using shared cookies #365
- 🐛(frontend) add default toolbar buttons #355
- 🐛(frontend) throttle error correctly display #378

## Removed

- 🔥(helm) remove infra related codes #366

---

**Full Changelog:** https://github.com/numerique-gouv/impress/compare/v1.6.0...v1.7.0

