### PR TITLE
✨(frontend) add useBroadcastStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 ## Added
 
 - 🌐(frontend) Add German translation #255
+- ✨(frontend) Add a broadcast store #387
 
 ## Changed
 
@@ -22,6 +23,7 @@ and this project adheres to
 
 - 🦺(backend) add comma to sub regex #408
 - 🐛(editor) collaborative user tag hidden when read only #385
+- 🐛(frontend) user have view access when revoked #387
 
 
 ## [1.7.0] - 2024-10-24

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/AIButton.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/AIButton.tsx
@@ -14,14 +14,13 @@ import { useTranslation } from 'react-i18next';
 
 import { isAPIError } from '@/api';
 import { Box, Text } from '@/components';
-import { useDocOptions } from '@/features/docs/doc-management/';
+import { useDocOptions, useDocStore } from '@/features/docs/doc-management/';
 
 import {
   AITransformActions,
   useDocAITransform,
   useDocAITranslate,
 } from '../api/';
-import { useDocStore } from '../stores';
 
 type LanguageTranslate = {
   value: string;

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
@@ -11,12 +11,11 @@ import { useTranslation } from 'react-i18next';
 import { Box, TextErrors } from '@/components';
 import { mediaUrl } from '@/core';
 import { useAuthStore } from '@/core/auth';
-import { Doc } from '@/features/docs/doc-management';
-import { Version } from '@/features/docs/doc-versioning/';
+import { Doc, useDocStore } from '@/features/docs/doc-management';
 
 import { useCreateDocAttachment } from '../api/useCreateDocUpload';
 import useSaveDoc from '../hook/useSaveDoc';
-import { useDocStore, useHeadingStore } from '../stores';
+import { useHeadingStore } from '../stores';
 import { randomColor } from '../utils';
 
 import { BlockNoteToolbar } from './BlockNoteToolbar';
@@ -76,39 +75,15 @@ const cssEditor = (readonly: boolean) => `
 
 interface BlockNoteEditorProps {
   doc: Doc;
-  version?: Version;
-}
-
-export const BlockNoteEditor = ({ doc, version }: BlockNoteEditorProps) => {
-  const { createProvider, docsStore } = useDocStore();
-  const storeId = version?.id || doc.id;
-  const initialContent = version?.content || doc.content;
-  const provider = docsStore?.[storeId]?.provider;
-
-  useEffect(() => {
-    if (!provider || provider.document.guid !== storeId) {
-      createProvider(storeId, initialContent);
-    }
-  }, [createProvider, initialContent, provider, storeId]);
-
-  if (!provider) {
-    return null;
-  }
-
-  return <BlockNoteContent doc={doc} provider={provider} storeId={storeId} />;
-};
-
-interface BlockNoteContentProps {
-  doc: Doc;
   provider: HocuspocusProvider;
   storeId: string;
 }
 
-export const BlockNoteContent = ({
+export const BlockNoteEditor = ({
   doc,
   provider,
   storeId,
-}: BlockNoteContentProps) => {
+}: BlockNoteEditorProps) => {
   const isVersion = doc.id !== storeId;
   const { userData } = useAuthStore();
   const { setStore, docsStore } = useDocStore();

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/stores/index.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/stores/index.ts
@@ -1,3 +1,2 @@
-export * from './useDocStore';
 export * from './useHeadingStore';
 export * from './usePanelEditorStore';

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/utils.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/utils.ts
@@ -1,5 +1,3 @@
-import * as Y from 'yjs';
-
 export const randomColor = () => {
   const randomInt = (min: number, max: number) => {
     return Math.floor(Math.random() * (max - min + 1)) + min;
@@ -28,20 +26,3 @@ function hslToHex(h: number, s: number, l: number) {
 export const toBase64 = (
   str: WithImplicitCoercion<ArrayBuffer | SharedArrayBuffer>,
 ) => Buffer.from(str).toString('base64');
-
-type BasicBlock = {
-  type: string;
-  content: string;
-};
-export const blocksToYDoc = (blocks: BasicBlock[], doc: Y.Doc) => {
-  const xmlFragment = doc.getXmlFragment('document-store');
-
-  blocks.forEach((block) => {
-    const xmlElement = new Y.XmlElement(block.type);
-    if (block.content) {
-      xmlElement.insert(0, [new Y.XmlText(block.content)]);
-    }
-
-    xmlFragment.push([xmlElement]);
-  });
-};

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/DocTitle.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/DocTitle.tsx
@@ -18,7 +18,7 @@ import {
   useTrans,
   useUpdateDoc,
 } from '@/features/docs/doc-management';
-import { useResponsiveStore } from '@/stores';
+import { useBroadcastStore, useResponsiveStore } from '@/stores';
 import { isFirefox } from '@/utils/userAgent';
 
 interface DocTitleProps {
@@ -54,6 +54,7 @@ const DocTitleInput = ({ doc }: DocTitleProps) => {
   const headingText = headings?.[0]?.contentText;
   const debounceRef = useRef<NodeJS.Timeout>();
   const { isMobile } = useResponsiveStore();
+  const { broadcast } = useBroadcastStore();
 
   const { mutate: updateDoc } = useUpdateDoc({
     listInvalideQueries: [KEY_DOC, KEY_LIST_DOC],
@@ -61,6 +62,9 @@ const DocTitleInput = ({ doc }: DocTitleProps) => {
       if (data.title !== untitledDocument) {
         toast(t('Document title updated successfully'), VariantType.SUCCESS);
       }
+
+      // Broadcast to every user connected to the document
+      broadcast(`${KEY_DOC}-${data.id}`);
     },
   });
 

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/DocToolBox.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/DocToolBox.tsx
@@ -8,11 +8,12 @@ import { useTranslation } from 'react-i18next';
 
 import { Box, DropButton, IconOptions } from '@/components';
 import { useAuthStore } from '@/core';
-import { useDocStore, usePanelEditorStore } from '@/features/docs/doc-editor/';
+import { usePanelEditorStore } from '@/features/docs/doc-editor/';
 import {
   Doc,
   ModalRemoveDoc,
   ModalShare,
+  useDocStore,
 } from '@/features/docs/doc-management';
 import { useResponsiveStore } from '@/stores';
 

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/ModalExport.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/ModalExport.tsx
@@ -14,8 +14,7 @@ import { t } from 'i18next';
 import { useEffect, useMemo, useState } from 'react';
 
 import { Box, Text } from '@/components';
-import { useDocStore } from '@/features/docs/doc-editor/';
-import { Doc } from '@/features/docs/doc-management';
+import { Doc, useDocStore } from '@/features/docs/doc-management';
 
 import { useExport } from '../api/useExport';
 import { TemplatesOrdering, useTemplates } from '../api/useTemplates';

--- a/src/frontend/apps/impress/src/features/docs/doc-management/index.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/index.ts
@@ -1,5 +1,6 @@
 export * from './api';
 export * from './components';
 export * from './hooks';
+export * from './stores';
 export * from './types';
 export * from './utils';

--- a/src/frontend/apps/impress/src/features/docs/doc-management/stores/index.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/stores/index.tsx
@@ -1,0 +1,1 @@
+export * from './useDocStore';

--- a/src/frontend/apps/impress/src/features/docs/doc-management/stores/useDocStore.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/stores/useDocStore.tsx
@@ -4,9 +4,7 @@ import * as Y from 'yjs';
 import { create } from 'zustand';
 
 import { providerUrl } from '@/core';
-import { Base64, Doc } from '@/features/docs/doc-management';
-
-import { blocksToYDoc } from '../utils';
+import { Base64, Doc, blocksToYDoc } from '@/features/docs/doc-management';
 
 interface DocStore {
   provider: HocuspocusProvider;

--- a/src/frontend/apps/impress/src/features/docs/doc-management/utils.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/utils.ts
@@ -1,3 +1,5 @@
+import * as Y from 'yjs';
+
 import { Doc, Role } from './types';
 
 export const currentDocRole = (abilities: Doc['abilities']): Role => {
@@ -8,4 +10,21 @@ export const currentDocRole = (abilities: Doc['abilities']): Role => {
       : abilities.partial_update
         ? Role.EDITOR
         : Role.READER;
+};
+
+type BasicBlock = {
+  type: string;
+  content: string;
+};
+export const blocksToYDoc = (blocks: BasicBlock[], doc: Y.Doc) => {
+  const xmlFragment = doc.getXmlFragment('document-store');
+
+  blocks.forEach((block) => {
+    const xmlElement = new Y.XmlElement(block.type);
+    if (block.content) {
+      xmlElement.insert(0, [new Y.XmlText(block.content)]);
+    }
+
+    xmlFragment.push([xmlElement]);
+  });
 };

--- a/src/frontend/apps/impress/src/features/docs/doc-table-content/components/TableContent.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-table-content/components/TableContent.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Box, BoxButton, Text } from '@/components';
-import { HeadingBlock, useDocStore } from '@/features/docs/doc-editor';
-import { Doc } from '@/features/docs/doc-management';
+import { HeadingBlock } from '@/features/docs/doc-editor';
+import { Doc, useDocStore } from '@/features/docs/doc-management';
 import { useResponsiveStore } from '@/stores';
 
 import { Heading } from './Heading';

--- a/src/frontend/apps/impress/src/features/docs/doc-versioning/components/ModalVersion.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-versioning/components/ModalVersion.tsx
@@ -11,8 +11,8 @@ import { useRouter } from 'next/navigation';
 import * as Y from 'yjs';
 
 import { Box, Text } from '@/components';
-import { toBase64, useDocStore } from '@/features/docs/doc-editor';
-import { Doc, useUpdateDoc } from '@/features/docs/doc-management';
+import { toBase64 } from '@/features/docs/doc-editor';
+import { Doc, useDocStore, useUpdateDoc } from '@/features/docs/doc-management';
 
 import { KEY_LIST_DOC_VERSIONS } from '../api/useDocVersions';
 import { Versions } from '../types';

--- a/src/frontend/apps/impress/src/features/docs/members/members-add/api/useCreateDocAccess.tsx
+++ b/src/frontend/apps/impress/src/features/docs/members/members-add/api/useCreateDocAccess.tsx
@@ -5,11 +5,13 @@ import { User } from '@/core/auth';
 import {
   Access,
   Doc,
+  KEY_DOC,
   KEY_LIST_DOC,
   Role,
 } from '@/features/docs/doc-management';
 import { KEY_LIST_DOC_ACCESSES } from '@/features/docs/members/members-list';
 import { ContentLanguage } from '@/i18n/types';
+import { useBroadcastStore } from '@/stores';
 
 import { OptionType } from '../types';
 
@@ -53,9 +55,11 @@ export const createDocAccess = async ({
 
 export function useCreateDocAccess() {
   const queryClient = useQueryClient();
+  const { broadcast } = useBroadcastStore();
+
   return useMutation<Access, APIError, CreateDocAccessParams>({
     mutationFn: createDocAccess,
-    onSuccess: () => {
+    onSuccess: (_data, variable) => {
       void queryClient.resetQueries({
         queryKey: [KEY_LIST_DOC],
       });
@@ -65,6 +69,9 @@ export function useCreateDocAccess() {
       void queryClient.resetQueries({
         queryKey: [KEY_LIST_DOC_ACCESSES],
       });
+
+      // Broadcast to every user connected to the document
+      broadcast(`${KEY_DOC}-${variable.docId}`);
     },
   });
 }

--- a/src/frontend/apps/impress/src/features/docs/members/members-list/api/useDeleteDocAccess.ts
+++ b/src/frontend/apps/impress/src/features/docs/members/members-list/api/useDeleteDocAccess.ts
@@ -7,6 +7,7 @@ import {
 import { APIError, errorCauses, fetchAPI } from '@/api';
 import { KEY_DOC, KEY_LIST_DOC } from '@/features/docs/doc-management';
 import { KEY_LIST_USER } from '@/features/docs/members/members-add';
+import { useBroadcastStore } from '@/stores';
 
 import { KEY_LIST_DOC_ACCESSES } from './useDocAccesses';
 
@@ -39,6 +40,8 @@ type UseDeleteDocAccessOptions = UseMutationOptions<
 
 export const useDeleteDocAccess = (options?: UseDeleteDocAccessOptions) => {
   const queryClient = useQueryClient();
+  const { broadcast } = useBroadcastStore();
+
   return useMutation<void, APIError, DeleteDocAccessProps>({
     mutationFn: deleteDocAccess,
     ...options,
@@ -49,6 +52,10 @@ export const useDeleteDocAccess = (options?: UseDeleteDocAccessOptions) => {
       void queryClient.invalidateQueries({
         queryKey: [KEY_DOC],
       });
+
+      // Broadcast to every user connected to the document
+      broadcast(`${KEY_DOC}-${variables.docId}`);
+
       void queryClient.resetQueries({
         queryKey: [KEY_LIST_DOC],
       });

--- a/src/frontend/apps/impress/src/features/docs/members/members-list/api/useUpdateDocAccess.ts
+++ b/src/frontend/apps/impress/src/features/docs/members/members-list/api/useUpdateDocAccess.ts
@@ -11,6 +11,7 @@ import {
   KEY_LIST_DOC,
   Role,
 } from '@/features/docs/doc-management';
+import { useBroadcastStore } from '@/stores';
 
 import { KEY_LIST_DOC_ACCESSES } from './useDocAccesses';
 
@@ -49,6 +50,8 @@ type UseUpdateDocAccessOptions = UseMutationOptions<
 
 export const useUpdateDocAccess = (options?: UseUpdateDocAccessOptions) => {
   const queryClient = useQueryClient();
+  const { broadcast } = useBroadcastStore();
+
   return useMutation<Access, APIError, UpdateDocAccessProps>({
     mutationFn: updateDocAccess,
     ...options,
@@ -59,6 +62,10 @@ export const useUpdateDocAccess = (options?: UseUpdateDocAccessOptions) => {
       void queryClient.invalidateQueries({
         queryKey: [KEY_DOC],
       });
+
+      // Broadcast to every user connected to the document
+      broadcast(`${KEY_DOC}-${variables.docId}`);
+
       void queryClient.invalidateQueries({
         queryKey: [KEY_LIST_DOC],
       });

--- a/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
+++ b/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
@@ -7,8 +7,8 @@ import { useEffect, useState } from 'react';
 import { Box, Text } from '@/components';
 import { TextErrors } from '@/components/TextErrors';
 import { useAuthStore } from '@/core/auth';
-import { DocEditor, useDocStore } from '@/features/docs';
-import { useDoc } from '@/features/docs/doc-management';
+import { DocEditor } from '@/features/docs/doc-editor';
+import { useDoc, useDocStore } from '@/features/docs/doc-management';
 import { MainLayout } from '@/layouts';
 import { NextPageWithLayout } from '@/types/next';
 
@@ -41,7 +41,7 @@ const DocPage = ({ id }: DocProps) => {
   const { login } = useAuthStore();
   const { data: docQuery, isError, error } = useDoc({ id });
   const [doc, setDoc] = useState(docQuery);
-  const { setCurrentDoc } = useDocStore();
+  const { setCurrentDoc, createProvider, docsStore } = useDocStore();
 
   const navigate = useNavigate();
 
@@ -65,6 +65,18 @@ const DocPage = ({ id }: DocProps) => {
       setCurrentDoc(undefined);
     };
   }, [docQuery, setCurrentDoc]);
+
+  useEffect(() => {
+    if (!doc?.id) {
+      return;
+    }
+
+    const provider = docsStore?.[doc.id]?.provider;
+
+    if (!provider || provider.document.guid !== doc.id) {
+      createProvider(doc.id, doc.content);
+    }
+  }, [createProvider, doc, docsStore]);
 
   if (isError && error) {
     if (error.status === 404) {

--- a/src/frontend/apps/impress/src/stores/index.ts
+++ b/src/frontend/apps/impress/src/stores/index.ts
@@ -1,1 +1,2 @@
+export * from './useBroadcastStore';
 export * from './useResponsiveStore';

--- a/src/frontend/apps/impress/src/stores/useBroadcastStore.tsx
+++ b/src/frontend/apps/impress/src/stores/useBroadcastStore.tsx
@@ -1,0 +1,54 @@
+import { HocuspocusProvider } from '@hocuspocus/provider';
+import * as Y from 'yjs';
+import { create } from 'zustand';
+
+interface BroadcastState {
+  addTask: (taskLabel: string, action: () => void) => void;
+  broadcast: (taskLabel: string) => void;
+  getBroadcastProvider: () => HocuspocusProvider | undefined;
+  provider?: HocuspocusProvider;
+  setBroadcastProvider: (provider: HocuspocusProvider) => void;
+  tasks: { [taskLabel: string]: Y.Array<string> };
+}
+
+export const useBroadcastStore = create<BroadcastState>((set, get) => ({
+  provider: undefined,
+  tasks: {},
+  setBroadcastProvider: (provider) => set({ provider }),
+  getBroadcastProvider: () => {
+    const provider = get().provider;
+    if (!provider) {
+      console.warn('Provider is not defined');
+      return;
+    }
+
+    return provider;
+  },
+  addTask: (taskLabel, action) => {
+    const taskExistAlready = get().tasks[taskLabel];
+    const provider = get().getBroadcastProvider();
+    if (taskExistAlready || !provider) {
+      return;
+    }
+
+    const task = provider.document.getArray<string>(taskLabel);
+    task.observe(() => {
+      action();
+    });
+
+    set((state) => ({
+      tasks: {
+        ...state.tasks,
+        [taskLabel]: task,
+      },
+    }));
+  },
+  broadcast: (taskLabel) => {
+    const task = get().tasks[taskLabel];
+    if (!task) {
+      console.warn(`Task ${taskLabel} is not defined`);
+      return;
+    }
+    task.push([`broadcast: ${taskLabel}`]);
+  },
+}));


### PR DESCRIPTION
## Purpose

Add the useBroadcastStore.
It will give us the ability to easily broadcast actions to all connected clients.

In this case, we needed to requery the doc to everyone when a change relative to the doc rights was made.

## Proposal

- [x] 🚚(frontend) move useDocStore to doc-management
- [x] ✨(frontend) add useBroadcastStore

## How to use:

Add any tasks:
```ts
const { setBroadcastProvider, addTask } = useBroadcastStore();
setBroadcastProvider(newProvider);
addTask(`hello`, () => {
      console.log("Hello world");
});

```
Broadcast it to everyone:
```ts
const { broadcast } = useBroadcastStore();
broadcast(`hello`);
// console.log("Hello world") will be displayed to every users
```

## Demo

2 different users, 1 on Chrome, the second on Firefox:

[scrnli_LZyuCI7HRjg5zv.webm](https://github.com/user-attachments/assets/2391477b-e653-464a-bc94-17014bbc64e7)
