### PR TITLE
🚸(backend) improve users similarity search and sort results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Changed
+
+- 🚸(backend) improve users similarity search and sort results #391
+
 ## [1.7.0] - 2024-10-24
 
 ## Added


### PR DESCRIPTION
## Purpose

In some edge cases, the domain part the email addresse is longer than the name part. Users searches by email similarity then return a lot of unsorted results.

## Proposal

- [x] We can improve this by being more demanding on similarity when the query looks like an email. 
- [x] Sorting results by the similarity score is also an obvious improvement.

At the moment, we still think it is good to propose results with a weak similarity on the name part because we want to avoid as much as possible creating duplicate users by inviting one of is many emails, a user who is already in our database.

Fixes #399 
