### PR TITLE
🦺(backend) add comma to sub regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to
 - 🚸(backend) improve users similarity search and sort results #391
 - 🌐(backend) add german translation #259
 
+## Fixed
+
+- 🦺(backend) add comma to sub regex #408
+
+
 ## [1.7.0] - 2024-10-24
 
 ## Added

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -130,17 +130,17 @@ class User(AbstractBaseUser, BaseModel, auth_models.PermissionsMixin):
     """User model to work with OIDC only authentication."""
 
     sub_validator = validators.RegexValidator(
-        regex=r"^[\w.@+-]+\Z",
+        regex=r"^[\w.@+-:]+\Z",
         message=_(
             "Enter a valid sub. This value may contain only letters, "
-            "numbers, and @/./+/-/_ characters."
+            "numbers, and @/./+/-/_/: characters."
         ),
     )
 
     sub = models.CharField(
         _("sub"),
         help_text=_(
-            "Required. 255 characters or fewer. Letters, numbers, and @/./+/-/_ characters only."
+            "Required. 255 characters or fewer. Letters, numbers, and @/./+/-/_/: characters only."
         ),
         max_length=255,
         unique=True,


### PR DESCRIPTION
## Purpose

Some sub have comma, the regex was a bit too strict and didn't allow it, this PR fixes that.
