### PR TITLE
✨(frontend) change visibility options order in dropdown menu

### DIFF
--- a/src/frontend/apps/impress/src/features/docs/doc-management/types.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/types.tsx
@@ -23,8 +23,8 @@ export enum Role {
 
 export enum LinkReach {
   RESTRICTED = 'restricted',
-  PUBLIC = 'public',
   AUTHENTICATED = 'authenticated',
+  PUBLIC = 'public',
 }
 
 export enum LinkRole {


### PR DESCRIPTION
## Purpose

This PR updates the option order to the following:
1. Restricted
2. Authenticated
3. Public

(issue #397 )

## Proposal

The options can be found from `LinkReach` in `/src/frontend/apps/impress/src/features/docs/doc-management/types.tsx`. Reordering them here will directly impact how they are displayed in the UI.
