### PR TITLE
🔒️(backend) whitelist the pod's IP address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to
 - 🌐(backend) add german translation #259
 - 🌐(frontend) Add German translation #255
 - ✨(frontend) Add a broadcast store #387
-- ✨(backend) config endpoint #425
+- ✨(backend) whitelist pod's IP address #443
 
 ## Changed
 

--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 
 import os
 import tomllib
+from socket import gethostbyname, gethostname
 
 from django.utils.translation import gettext_lazy as _
 
@@ -649,7 +650,13 @@ class Production(Base):
     """
 
     # Security
-    ALLOWED_HOSTS = values.ListValue(None)
+    # Add allowed host from environment variables.
+    # The machine hostname is added by default,
+    # it makes the application pingable by a load balancer on the same machine by example
+    ALLOWED_HOSTS = [
+        *values.ListValue([], environ_name="ALLOWED_HOSTS"),
+        gethostbyname(gethostname()),
+    ]
     CSRF_TRUSTED_ORIGINS = values.ListValue([])
     SECURE_BROWSER_XSS_FILTER = True
     SECURE_CONTENT_TYPE_NOSNIFF = True


### PR DESCRIPTION
## Purpose

In a Kubernetes environment, we need to whitelist the pod's IP address to allow health checks to pass. This ensures that Kubernetes liveness and readiness probes can access the application to verify its health.

Based on this commit: https://github.com/numerique-gouv/meet/commit/d965ee706014b6395fdb2d2ce0f3e4f520f64503
