### PR TITLE
✅(CI) trivy continue on error

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           docker-build-args: '--target backend-production -f Dockerfile'
           docker-image-name: 'docker.io/lasuite/impress-backend:${{ github.sha }}'
+        continue-on-error: true
       -
         name: Build and push
         uses: docker/build-push-action@v6
@@ -105,6 +106,7 @@ jobs:
         with:
           docker-build-args: '-f src/frontend/Dockerfile --target frontend-production'
           docker-image-name: 'docker.io/lasuite/impress-frontend:${{ github.sha }}'
+        continue-on-error: true
       -
         name: Build and push
         uses: docker/build-push-action@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to
 - 🚸(backend) improve users similarity search and sort results #391
 - ♻️(frontend) simplify stores #402
 - ✨(frontend) update $css Box props type to add styled components RuleSet #423
+- ✅(CI) trivy continue on error #453
 
 ## Fixed
 


### PR DESCRIPTION
## Purpose

Trivy is extremly flaky, we need to continue on error to avoid blocking the pipeline.
We still keep the check, to see if there are any vulnerabilities, but we don't want to block the pipeline.
