### PR TITLE
🩹 Fine tuning 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to
 - 🦺(backend) add comma to sub regex #408
 - 🐛(editor) collaborative user tag hidden when read only #385
 - 🐛(frontend) users have view access when revoked #387
+- 🐛(frontend) fix placeholder editable when double clicks #454
 
 
 ## [1.7.0] - 2024-10-24

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/DocTitle.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/DocTitle.tsx
@@ -57,7 +57,7 @@ const DocTitleInput = ({ doc }: DocTitleProps) => {
   const { broadcast } = useBroadcastStore();
 
   const { mutate: updateDoc } = useUpdateDoc({
-    listInvalideQueries: [KEY_DOC, KEY_LIST_DOC],
+    listInvalideQueries: [KEY_LIST_DOC],
     onSuccess(data) {
       if (data.title !== untitledDocument) {
         toast(t('Document title updated successfully'), VariantType.SUCCESS);
@@ -105,6 +105,10 @@ const DocTitleInput = ({ doc }: DocTitleProps) => {
   };
 
   useEffect(() => {
+    setTitleDisplay(doc.title);
+  }, [doc.title]);
+
+  useEffect(() => {
     if ((!debounceRef.current && !isUntitled) || !headingText) {
       return;
     }
@@ -129,6 +133,7 @@ const DocTitleInput = ({ doc }: DocTitleProps) => {
           $radius="4px"
           $padding={{ horizontal: 'tiny', vertical: '4px' }}
           $margin="none"
+          $minWidth="200px"
           contentEditable={isFirefox() ? 'true' : 'plaintext-only'}
           onClick={handleOnClick}
           onBlurCapture={(e) =>

--- a/src/frontend/apps/impress/src/services/Crisp.tsx
+++ b/src/frontend/apps/impress/src/services/Crisp.tsx
@@ -19,6 +19,7 @@ export const configureCrispSession = (websiteId: string) => {
     return;
   }
   Crisp.configure(websiteId);
+  Crisp.setSafeMode(true);
 };
 
 export const terminateCrispSession = () => {


### PR DESCRIPTION
## Purpose

Small fixes from the review of on preproduction of the version 1.8.0.

## Proposal

- [x] 🚨(frontend) remove Crisp warning
- [x] 🐛(frontend) fix rerender title with broadcasting
