### PR TITLE
✨(frontend) implement document filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
 - 💄(frontend) update DocsGridOptions component #432
 - 💄(frontend) update DocHeader ui #446
 - 💄(frontend) update doc versioning ui #463
+- 💄(frontend) update doc home left panel #475
 
 ## [1.8.2] - 2024-11-28
 

--- a/src/frontend/apps/impress/src/features/docs/doc-management/api/useDocs.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/api/useDocs.tsx
@@ -28,16 +28,24 @@ export type DocsOrdering = (typeof docsOrdering)[number];
 export type DocsParams = {
   page: number;
   ordering?: DocsOrdering;
+  is_creator_me?: boolean;
 };
 
 export type DocsResponse = APIList<Doc>;
+export const getDocs = async (params: DocsParams): Promise<DocsResponse> => {
+  const searchParams = new URLSearchParams();
+  if (params.page) {
+    searchParams.set('page', params.page.toString());
+  }
 
-export const getDocs = async ({
-  ordering,
-  page,
-}: DocsParams): Promise<DocsResponse> => {
-  const orderingQuery = ordering ? `&ordering=${ordering}` : '';
-  const response = await fetchAPI(`documents/?page=${page}${orderingQuery}`);
+  if (params.ordering) {
+    searchParams.set('ordering', params.ordering);
+  }
+  if (params.is_creator_me !== undefined) {
+    searchParams.set('is_creator_me', params.is_creator_me.toString());
+  }
+
+  const response = await fetchAPI(`documents/?${searchParams.toString()}`);
 
   if (!response.ok) {
     throw new APIError('Failed to get the docs', await errorCauses(response));

--- a/src/frontend/apps/impress/src/features/docs/doc-management/types.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/types.tsx
@@ -59,3 +59,9 @@ export interface Doc {
     versions_retrieve: boolean;
   };
 }
+
+export enum DocDefaultFilter {
+  ALL_DOCS = 'all_docs',
+  MY_DOCS = 'my_docs',
+  SHARED_WITH_ME = 'shared_with_me',
+}

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGrid.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGrid.tsx
@@ -5,12 +5,17 @@ import { InView } from 'react-intersection-observer';
 import { Box, Card, Text } from '@/components';
 import { useResponsiveStore } from '@/stores';
 
-import { useInfiniteDocs } from '../../doc-management';
+import { DocDefaultFilter, useInfiniteDocs } from '../../doc-management';
 
 import { DocsGridItem } from './DocsGridItem';
 import { DocsGridLoader } from './DocsGridLoader';
 
-export const DocsGrid = () => {
+type DocsGridProps = {
+  target?: DocDefaultFilter;
+};
+export const DocsGrid = ({
+  target = DocDefaultFilter.ALL_DOCS,
+}: DocsGridProps) => {
   const { t } = useTranslation();
 
   const { isDesktop } = useResponsiveStore();
@@ -24,6 +29,10 @@ export const DocsGrid = () => {
     hasNextPage,
   } = useInfiniteDocs({
     page: 1,
+    ...(target &&
+      target !== DocDefaultFilter.ALL_DOCS && {
+        is_creator_me: target === DocDefaultFilter.MY_DOCS,
+      }),
   });
   const loading = isFetching || isLoading;
 

--- a/src/frontend/apps/impress/src/features/left-panel/components/LefPanelTargetFilters.tsx
+++ b/src/frontend/apps/impress/src/features/left-panel/components/LefPanelTargetFilters.tsx
@@ -1,0 +1,93 @@
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { css } from 'styled-components';
+
+import { Box, BoxButton, Icon, Text } from '@/components';
+import { useCunninghamTheme } from '@/cunningham';
+import { DocDefaultFilter } from '@/features/docs';
+import { useLeftPanelStore } from '@/features/left-panel';
+
+export const LeftPanelTargetFilters = () => {
+  const { t } = useTranslation();
+  const pathname = usePathname();
+  const { togglePanel } = useLeftPanelStore();
+  const { colorsTokens, spacingsTokens } = useCunninghamTheme();
+  const spacing = spacingsTokens();
+  const colors = colorsTokens();
+
+  const searchParams = useSearchParams();
+  const target =
+    (searchParams.get('target') as DocDefaultFilter) ??
+    DocDefaultFilter.ALL_DOCS;
+
+  const router = useRouter();
+
+  const defaultQueries = useMemo(() => {
+    return [
+      {
+        icon: 'apps',
+        label: t('All docs'),
+        targetQuery: DocDefaultFilter.ALL_DOCS,
+      },
+      {
+        icon: 'lock',
+        label: t('My docs'),
+        targetQuery: DocDefaultFilter.MY_DOCS,
+      },
+      {
+        icon: 'group',
+        label: t('Shared with me'),
+        targetQuery: DocDefaultFilter.SHARED_WITH_ME,
+      },
+    ];
+  }, [t]);
+
+  const onSelectQuery = (query: DocDefaultFilter) => {
+    const params = new URLSearchParams(searchParams);
+    params.set('target', query);
+    router.replace(`${pathname}?${params.toString()}`);
+    togglePanel();
+  };
+
+  return (
+    <Box
+      $justify="center"
+      $padding={{ horizontal: 'xs' }}
+      $gap={spacing['2xs']}
+    >
+      {defaultQueries.map((query) => {
+        const isActive = target === query.targetQuery;
+
+        return (
+          <BoxButton
+            aria-label={query.label}
+            key={query.label}
+            onClick={() => onSelectQuery(query.targetQuery)}
+            $direction="row"
+            aria-selected={isActive}
+            $align="center"
+            $justify="flex-start"
+            $gap={spacing['xs']}
+            $radius={spacing['2xs']}
+            $padding={{ all: 'xs' }}
+            $css={css`
+              cursor: pointer;
+              background-color: ${isActive
+                ? colors['greyscale-100']
+                : undefined};
+              font-weight: ${isActive ? 700 : undefined};
+              &:hover {
+                background-color: ${colors['greyscale-100']};
+                font-weight: 700;
+              }
+            `}
+          >
+            <Icon $variation="1000" iconName={query.icon} />
+            <Text $variation="1000">{query.label}</Text>
+          </BoxButton>
+        );
+      })}
+    </Box>
+  );
+};

--- a/src/frontend/apps/impress/src/features/left-panel/components/LeftPanel.tsx
+++ b/src/frontend/apps/impress/src/features/left-panel/components/LeftPanel.tsx
@@ -1,4 +1,3 @@
-import { PropsWithChildren } from 'react';
 import { createGlobalStyle, css } from 'styled-components';
 
 import { Box, SeparatedSection } from '@/components';
@@ -10,6 +9,7 @@ import { useResponsiveStore } from '@/stores';
 
 import { useLeftPanelStore } from '../stores';
 
+import { LeftPanelContent } from './LeftPanelContent';
 import { LeftPanelHeader } from './LeftPanelHeader';
 
 const MobileLeftPanelStyle = createGlobalStyle`
@@ -18,7 +18,7 @@ const MobileLeftPanelStyle = createGlobalStyle`
   }
 `;
 
-export const LeftPanel = ({ children }: PropsWithChildren) => {
+export const LeftPanel = () => {
   const { isDesktop } = useResponsiveStore();
   const { isPanelOpen } = useLeftPanelStore();
   const theme = useCunninghamTheme();
@@ -37,7 +37,8 @@ export const LeftPanel = ({ children }: PropsWithChildren) => {
             border-right: 1px solid ${colors['greyscale-200']};
         `}
         >
-          <LeftPanelHeader>{children}</LeftPanelHeader>
+          <LeftPanelHeader />
+          <LeftPanelContent />
         </Box>
       )}
 
@@ -65,7 +66,8 @@ export const LeftPanel = ({ children }: PropsWithChildren) => {
                 gap: ${spacings['base']};
               `}
             >
-              <LeftPanelHeader>{children}</LeftPanelHeader>
+              <LeftPanelHeader />
+              <LeftPanelContent />
               <SeparatedSection showSeparator={false}>
                 <Box $justify="center" $align="center" $gap={spacings['sm']}>
                   <ButtonLogin />

--- a/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelContent.tsx
+++ b/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelContent.tsx
@@ -1,0 +1,20 @@
+import { useRouter } from 'next/router';
+
+import { Box, SeparatedSection } from '@/components';
+
+import { LeftPanelTargetFilters } from './LefPanelTargetFilters';
+
+export const LeftPanelContent = () => {
+  const router = useRouter();
+  const isHome = router.pathname === '/';
+
+  return (
+    <Box>
+      {isHome && (
+        <SeparatedSection>
+          <LeftPanelTargetFilters />
+        </SeparatedSection>
+      )}
+    </Box>
+  );
+};

--- a/src/frontend/apps/impress/src/pages/docs/index.tsx
+++ b/src/frontend/apps/impress/src/pages/docs/index.tsx
@@ -1,14 +1,19 @@
+import { useSearchParams } from 'next/navigation';
 import type { ReactElement } from 'react';
 
 import { Box } from '@/components';
+import { DocDefaultFilter } from '@/features/docs';
 import { DocsGrid } from '@/features/docs/docs-grid/components/DocsGrid';
 import { MainLayout } from '@/layouts';
 import { NextPageWithLayout } from '@/types/next';
 
 const Page: NextPageWithLayout = () => {
+  const searchParams = useSearchParams();
+  const target = searchParams.get('target');
+
   return (
     <Box $width="100%" $align="center">
-      <DocsGrid />
+      <DocsGrid target={target as DocDefaultFilter} />
     </Box>
   );
 };


### PR DESCRIPTION
- Introduced a new enum for default document filters to improve code clarity.
- Updated the API call to support filtering documents based on the creator.
- Enhanced the DocsGrid component to accept a target filter, allowing dynamic content rendering based on user selection.
- Modified the main layout to include a left panel for improved navigation and user experience.
- Added a new test suite for document filters, verifying the visibility and selection states of 'All docs', 'My docs', and 'Shared with me'.




https://github.com/user-attachments/assets/55457882-69ae-4df6-a7a6-4be2357a64eb


