### PR TITLE
:wrench:(helm) add option to disable default tls setting

### DIFF
--- a/src/helm/impress/templates/ingress.yaml
+++ b/src/helm/impress/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
   {{- end }}
   {{- if .Values.ingress.tls.enabled }}
   tls:
-    {{- if .Values.ingress.host }}
+    {{- if and .Values.ingress.host .Values.ingress.tls.useDefaultSecretName }}
     - secretName: {{ $fullName }}-tls
       hosts:
         - {{ .Values.ingress.host | quote }}

--- a/src/helm/impress/templates/ingress_admin.yaml
+++ b/src/helm/impress/templates/ingress_admin.yaml
@@ -28,7 +28,7 @@ spec:
   {{- end }}
   {{- if .Values.ingressAdmin.tls.enabled }}
   tls:
-    {{- if .Values.ingressAdmin.host }}
+    {{- if and .Values.ingressAdmin.host .Values.ingressAdmin.tls.useDefaultSecretName }}
     - secretName: {{ $fullName }}-tls
       hosts:
         - {{ .Values.ingressAdmin.host | quote }}

--- a/src/helm/impress/templates/ingress_media.yaml
+++ b/src/helm/impress/templates/ingress_media.yaml
@@ -28,7 +28,7 @@ spec:
   {{- end }}
   {{- if .Values.ingressMedia.tls.enabled }}
   tls:
-    {{- if .Values.ingressMedia.host }}
+    {{- if and .Values.ingressMedia.host .Values.ingressMedia.tls.useDefaultSecretName }}
     - secretName: {{ $fullName }}-tls
       hosts:
         - {{ .Values.ingressMedia.host | quote }}

--- a/src/helm/impress/templates/ingress_ws.yaml
+++ b/src/helm/impress/templates/ingress_ws.yaml
@@ -28,7 +28,7 @@ spec:
   {{- end }}
   {{- if .Values.ingressWS.tls.enabled }}
   tls:
-    {{- if .Values.ingressWS.host }}
+    {{- if and .Values.ingressWS.host .Values.ingressWS.tls.useDefaultSecretName }}
     - secretName: {{ $fullName }}-tls
       hosts:
         - {{ .Values.ingressWS.host | quote }}

--- a/src/helm/impress/values.yaml
+++ b/src/helm/impress/values.yaml
@@ -37,12 +37,14 @@ ingress:
   ## @param ingress.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
-  ## @param ingress.tls.enabled Wether to enable TLS for the Ingress
+  ## @param ingress.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingress.tls.useDefaultSecretName Weather to use default <name>-tls as secretName
   ## @skip ingress.tls.additional
   ## @extra ingress.tls.additional[].secretName Secret name for additional TLS config
   ## @extra ingress.tls.additional[].hosts[] Hosts for additional TLS config
   tls:
     enabled: true
+    useDefaultSecretName: true
     additional: []
 
   ## @param ingress.customBackends Add custom backends to ingress
@@ -60,12 +62,14 @@ ingressWS:
   ## @param ingress.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
-  ## @param ingressWS.tls.enabled Wether to enable TLS for the Ingress
+  ## @param ingressWS.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressWS.tls.useDefaultSecretName Weather to use default <name>-tls as secretName
   ## @skip ingressWS.tls.additional
   ## @extra ingressWS.tls.additional[].secretName Secret name for additional TLS config
   ## @extra ingressWS.tls.additional[].hosts[] Hosts for additional TLS config
   tls:
     enabled: true
+    useDefaultSecretName: true
     additional: []
 
   ## @param ingressWS.customBackends Add custom backends to ingress
@@ -87,12 +91,14 @@ ingressAdmin:
   ## @param ingressAdmin.hosts Additional host to configure for the Ingress
   hosts: [ ]
   #  - chart-example.local
-  ## @param ingressAdmin.tls.enabled Wether to enable TLS for the Ingress
+  ## @param ingressAdmin.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressAdmin.tls.useDefaultSecretName Weather to use default <name>-tls as secretName
   ## @skip ingressAdmin.tls.additional
   ## @extra ingressAdmin.tls.additional[].secretName Secret name for additional TLS config
   ## @extra ingressAdmin.tls.additional[].hosts[] Hosts for additional TLS config
   tls:
     enabled: true
+    useDefaultSecretName: true
     additional: []
 
 ## @param ingressMedia.enabled whether to enable the Ingress or not
@@ -107,12 +113,14 @@ ingressMedia:
   ## @param ingressMedia.hosts Additional host to configure for the Ingress
   hosts: [ ]
   #  - chart-example.local
-  ## @param ingressMedia.tls.enabled Wether to enable TLS for the Ingress
+  ## @param ingressMedia.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressMedia.tls.useDefaultSecretName Weather to use default <name>-tls as secretName
   ## @skip ingressMedia.tls.additional
   ## @extra ingressMedia.tls.additional[].secretName Secret name for additional TLS config
   ## @extra ingressMedia.tls.additional[].hosts[] Hosts for additional TLS config
   tls:
     enabled: true
+    useDefaultSecretName: true
     additional: []
 
   annotations:


### PR DESCRIPTION
## Purpose

This merge requests sets an option for those who uses impress with a different secretName in ingress.

This defaults does not change the current deployments.
