### PR TITLE
🐛(frontend) fix doc grid button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
 - 💄(frontend) update DocsGridOptions component #432
 - 💄(frontend) update DocHeader ui #446
 - 💄(frontend) update doc versioning ui #463
+- 🐛(frontend) fix doc grid button #478
 - 💄(frontend) update doc home left panel #475
 
 ## [1.8.2] - 2024-11-28

--- a/src/frontend/apps/impress/src/cunningham/cunningham-style.css
+++ b/src/frontend/apps/impress/src/cunningham/cunningham-style.css
@@ -356,6 +356,10 @@ input:-webkit-autofill:focus {
   gap: var(--c--theme--spacings--2xs);
 }
 
+.c__button--nano.c__button--icon-only {
+  width: auto;
+}
+
 .c__button--medium {
   padding: 0.9rem var(--c--theme--spacings--s);
 }

--- a/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelContent.tsx
+++ b/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelContent.tsx
@@ -9,7 +9,7 @@ export const LeftPanelContent = () => {
   const isHome = router.pathname === '/';
 
   return (
-    <Box>
+    <Box $width="100%">
       {isHome && (
         <SeparatedSection>
           <LeftPanelTargetFilters />


### PR DESCRIPTION
## Purpose

the nano button is broken 

<img width="1028" alt="Capture d’écran 2024-12-05 à 15 35 22" src="https://github.com/user-attachments/assets/394ede2f-dc73-4ad9-8d82-e7ed57fddac0">

