### PR TITLE
🎨Unlossy AI translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Added
+
+- ✨(backend) annotate number of accesses on documents in list view #411
+- ✨(backend) allow users to mark/unmark documents as favorite #411
+
+## Changes
+
+- ⚡️(backend) optimize number of queries on document list view #411
+
 
 ## [1.8.2] - 2024-11-28
 
@@ -28,8 +37,6 @@ and this project adheres to
 
 ## Added
 
-- ✨(backend) annotate number of accesses on documents in list view #411
-- ✨(backend) allow users to mark/unmark documents as favorite #411
 - 🌐(backend) add German translation #259
 - 🌐(frontend) add German translation #255
 - ✨(frontend) add a broadcast store #387
@@ -41,7 +48,6 @@ and this project adheres to
 
 ## Changed
 
-- ⚡️(backend) optimize number of queries on document list view #411
 - 🚸(backend) improve users similarity search and sort results #391
 - ♻️(frontend) simplify stores #402
 - ✨(frontend) update $css Box props type to add styled components RuleSet #423

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to
 
 ## Changes
 
+- ♻️(frontend) Improve Ai translations #478
+- 🐛(frontend) Fix hidden menu on Firefox #468
 - ⚡️(backend) optimize number of queries on document list view #411
 
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -426,11 +426,12 @@ class AITranslateSerializer(serializers.Serializer):
     language = serializers.ChoiceField(
         choices=tuple(enums.ALL_LANGUAGES.items()), required=True
     )
-    text = serializers.CharField(required=True)
+    text = serializers.JSONField(required=True)
 
     def validate_text(self, value):
         """Ensure the text field is not empty."""
 
-        if len(value.strip()) == 0:
-            raise serializers.ValidationError("Text field cannot be empty.")
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("Text field must be a json object.")
+
         return value

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -680,9 +680,9 @@ class DocumentViewSet(
         """
         POST /api/v1.0/documents/<resource_id>/ai-translate
         with expected data:
-        - text: str
+        - text: json
         - language: str [settings.LANGUAGES]
-        Return JSON response with the translated text.
+        Return the same json but with the value updated, keep the keys accordingly.
         """
         # Check permissions first
         self.get_object()

--- a/src/backend/core/services/ai_services.py
+++ b/src/backend/core/services/ai_services.py
@@ -15,29 +15,33 @@ AI_ACTIONS = {
         "Answer the prompt in markdown format. Return JSON: "
         '{"answer": "Your markdown answer"}. '
         "Do not provide any other information."
+        "Preserve the language."
     ),
     "correct": (
         "Correct grammar and spelling of the markdown text, "
         "preserving language and markdown formatting. "
         'Return JSON: {"answer": "your corrected markdown text"}. '
         "Do not provide any other information."
+        "Preserve the language."
     ),
     "rephrase": (
         "Rephrase the given markdown text, "
         "preserving language and markdown formatting. "
         'Return JSON: {"answer": "your rephrased markdown text"}. '
         "Do not provide any other information."
+        "Preserve the language."
     ),
     "summarize": (
         "Summarize the markdown text, preserving language and markdown formatting. "
         'Return JSON: {"answer": "your markdown summary"}. '
         "Do not provide any other information."
+        "Preserve the language."
     ),
 }
 
 AI_TRANSLATE = (
-    "Translate the markdown text to {language:s}, preserving markdown formatting. "
-    'Return JSON: {{"answer": "your translated markdown text in {language:s}"}}. '
+    "Translate to {language:s} for every value of the json provided."
+    "Keep the same json but with the value updated, keep the keys accordingly."
     "Do not provide any other information."
 )
 
@@ -62,7 +66,7 @@ class AIService:
             response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": system_content},
-                {"role": "user", "content": json.dumps({"markdown_input": text})},
+                {"role": "user", "content": json.dumps({"answer": text})},
             ],
         )
 

--- a/src/backend/core/tests/documents/test_api_documents_ai_transform.py
+++ b/src/backend/core/tests/documents/test_api_documents_ai_transform.py
@@ -86,9 +86,10 @@ def test_api_documents_ai_transform_anonymous_success(mock_create):
                     "Summarize the markdown text, preserving language and markdown formatting. "
                     'Return JSON: {"answer": "your markdown summary"}. Do not provide any other '
                     "information."
+                    "Preserve the language."
                 ),
             },
-            {"role": "user", "content": '{"markdown_input": "Hello"}'},
+            {"role": "user", "content": '{"answer": "Hello"}'},
         ],
     )
 
@@ -163,9 +164,10 @@ def test_api_documents_ai_transform_authenticated_success(mock_create, reach, ro
                 "content": (
                     'Answer the prompt in markdown format. Return JSON: {"answer": '
                     '"Your markdown answer"}. Do not provide any other information.'
+                    "Preserve the language."
                 ),
             },
-            {"role": "user", "content": '{"markdown_input": "Hello"}'},
+            {"role": "user", "content": '{"answer": "Hello"}'},
         ],
     )
 
@@ -239,9 +241,10 @@ def test_api_documents_ai_transform_success(mock_create, via, role, mock_user_te
                 "content": (
                     'Answer the prompt in markdown format. Return JSON: {"answer": '
                     '"Your markdown answer"}. Do not provide any other information.'
+                    "Preserve the language."
                 ),
             },
-            {"role": "user", "content": '{"markdown_input": "Hello"}'},
+            {"role": "user", "content": '{"answer": "Hello"}'},
         ],
     )
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-editor.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-editor.spec.ts
@@ -262,7 +262,7 @@ test.describe('Doc Editor', () => {
       if (request.method().includes('POST')) {
         await route.fulfill({
           json: {
-            answer: 'Bonjour le monde',
+            answer: { 'tid-0': 'Bonjour le monde' },
           },
         });
       } else {

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/api/useDocAITranslate.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/api/useDocAITranslate.tsx
@@ -4,12 +4,12 @@ import { APIError, errorCauses, fetchAPI } from '@/api';
 
 export type DocAITranslate = {
   docId: string;
-  text: string;
+  text: Record<string, string>;
   language: string;
 };
 
 export type DocAITranslateResponse = {
-  answer: string;
+  answer: Record<string, string>;
 };
 
 export const docAITranslate = async ({

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/utilsAI.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/utilsAI.ts
@@ -2,7 +2,7 @@ import { Block as CoreBlock } from '@blocknote/core';
 
 type Block = Omit<CoreBlock, 'type'> & {
   tid?: string;
-  type: string;
+  type?: string;
   text?: string;
   content: Block[] | Block;
   children?: Block[] | Block;
@@ -21,7 +21,7 @@ export function addIdToTextNodes(node: Node) {
   if (Array.isArray(node)) {
     node.forEach((child) => addIdToTextNodes(child));
   } else if (typeof node === 'object' && node !== null) {
-    if (node.type === 'text') {
+    if (node?.type === 'text') {
       node.tid = generateId();
     }
 
@@ -37,7 +37,7 @@ export function addIdToTextNodes(node: Node) {
     // Handle table content
     if (
       !Array.isArray(node.content) &&
-      node.type === 'table' &&
+      node?.type === 'table' &&
       node.content &&
       node.content.type === 'tableContent'
     ) {
@@ -63,7 +63,7 @@ export function extractTextWithId(
   if (Array.isArray(node)) {
     node.forEach((child) => extractTextWithId(child, texts));
   } else if (typeof node === 'object' && node !== null) {
-    if (node.type === 'text' && node.tid) {
+    if (node?.type === 'text' && node.tid) {
       texts[node.tid] = node.text || '';
     }
 
@@ -79,7 +79,7 @@ export function extractTextWithId(
     // Handle table content
     if (
       !Array.isArray(node.content) &&
-      node.type === 'table' &&
+      node?.type === 'table' &&
       node.content &&
       node.content.type === 'tableContent'
     ) {
@@ -107,7 +107,7 @@ export function updateTextsWithId(
     node.forEach((child) => updateTextsWithId(child, updatedTexts));
   } else if (typeof node === 'object' && node !== null) {
     if (
-      node.type === 'text' &&
+      node?.type === 'text' &&
       node.tid &&
       updatedTexts[node.tid] !== undefined
     ) {
@@ -126,7 +126,7 @@ export function updateTextsWithId(
     // Handle table content
     if (
       !Array.isArray(node.content) &&
-      node.type === 'table' &&
+      node?.type === 'table' &&
       node.content &&
       node.content.type === 'tableContent'
     ) {

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/utilsAI.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/utilsAI.ts
@@ -1,0 +1,145 @@
+import { Block as CoreBlock } from '@blocknote/core';
+
+type Block = Omit<CoreBlock, 'type'> & {
+  tid?: string;
+  type: string;
+  text?: string;
+  content: Block[] | Block;
+  children?: Block[] | Block;
+};
+export type Node = Block[] | Block;
+
+let idCounter = 0;
+
+// Function to generate a unique id
+function generateId() {
+  return `tid-${idCounter++}`;
+}
+
+// Function to add a unique id to each text node
+export function addIdToTextNodes(node: Node) {
+  if (Array.isArray(node)) {
+    node.forEach((child) => addIdToTextNodes(child));
+  } else if (typeof node === 'object' && node !== null) {
+    if (node.type === 'text') {
+      node.tid = generateId();
+    }
+
+    // Recursively process content and children
+    if (node.content) {
+      addIdToTextNodes(node.content);
+    }
+
+    if (node.children) {
+      addIdToTextNodes(node.children);
+    }
+
+    // Handle table content
+    if (
+      !Array.isArray(node.content) &&
+      node.type === 'table' &&
+      node.content &&
+      node.content.type === 'tableContent'
+    ) {
+      const tableContent = node.content;
+      if (tableContent.rows) {
+        tableContent.rows.forEach((row) => {
+          if (row.cells) {
+            row.cells.forEach((cell) => {
+              addIdToTextNodes(cell as unknown as Node);
+            });
+          }
+        });
+      }
+    }
+  }
+}
+
+// Function to extract texts with their tids into a flat JSON object
+export function extractTextWithId(
+  node: Node,
+  texts: Record<string, string> = {},
+) {
+  if (Array.isArray(node)) {
+    node.forEach((child) => extractTextWithId(child, texts));
+  } else if (typeof node === 'object' && node !== null) {
+    if (node.type === 'text' && node.tid) {
+      texts[node.tid] = node.text || '';
+    }
+
+    // Recursively process content and children
+    if (node.content) {
+      extractTextWithId(node.content, texts);
+    }
+
+    if (node.children) {
+      extractTextWithId(node.children, texts);
+    }
+
+    // Handle table content
+    if (
+      !Array.isArray(node.content) &&
+      node.type === 'table' &&
+      node.content &&
+      node.content.type === 'tableContent'
+    ) {
+      const tableContent = node.content;
+      if (tableContent.rows) {
+        tableContent.rows.forEach((row) => {
+          if (row.cells) {
+            row.cells.forEach((cell) => {
+              extractTextWithId(cell as unknown as Node, texts);
+            });
+          }
+        });
+      }
+    }
+  }
+  return texts;
+}
+
+// Function to update the original JSON using a second JSON containing updated texts
+export function updateTextsWithId(
+  node: Node,
+  updatedTexts: Record<string, string>,
+) {
+  if (Array.isArray(node)) {
+    node.forEach((child) => updateTextsWithId(child, updatedTexts));
+  } else if (typeof node === 'object' && node !== null) {
+    if (
+      node.type === 'text' &&
+      node.tid &&
+      updatedTexts[node.tid] !== undefined
+    ) {
+      node.text = updatedTexts[node.tid];
+    }
+
+    // Recursively process content and children
+    if (node.content) {
+      updateTextsWithId(node.content, updatedTexts);
+    }
+
+    if (node.children) {
+      updateTextsWithId(node.children, updatedTexts);
+    }
+
+    // Handle table content
+    if (
+      !Array.isArray(node.content) &&
+      node.type === 'table' &&
+      node.content &&
+      node.content.type === 'tableContent'
+    ) {
+      const tableContent = node.content;
+      if (tableContent.rows) {
+        tableContent.rows.forEach((row) => {
+          if (row.cells) {
+            row.cells.forEach((cell) => {
+              updateTextsWithId(cell as unknown as Node, updatedTexts);
+            });
+          }
+        });
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

To translate with the AI we were using lossy functions (`blocksToMarkdownLossy` / `tryParseMarkdownToBlocks`), so we were loosing indentations, colors, background, lot of formatting. Some errors were popping up as well about tables loosing ids after the translation.

## Proposal

- We are now keeping the Blocknote json structure. 
- We associate an id to every node with the type text ([see](https://github.com/numerique-gouv/impress/pull/479/files#diff-e0d57a4975c27ca89a6756f94ae486adb23e7a844fa553ce45a6c1d619c961f0R24-R26))
- We extract the text with the id in a json
- We send only this json to the AI:
```json
{
    "tid-102": "Hello",
    "tid-103": "world",
    "tid-104": "Nice",
}
```
- The AI send back the same json with the translation:
```json
{
    "tid-102": "Bonjour",
    "tid-103": "le monde",
    "tid-104": "Super",
}
```
- We replace in the json Blocknote the text with the ID associated
- We replace in the editor the previous blocks with the new ones, block by block in checking if the block is still existing in the editor.

## Demo

[scrnli_ulUKPeGj2U7Hbw.webm](https://github.com/user-attachments/assets/b5fbb254-a227-4358-b764-378e70660821)