### PR TITLE
🐛(frontend) fix initial content with collaboration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to
 
 ## Fixed
 
+- 🐛(frontend) fix initial content with collaboration #484
 - 🐛(frontend) Fix hidden menu on Firefox #468
 - 🐛(backend) fix sanitize problem IA #490
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
@@ -128,6 +128,23 @@ export const BlockNoteEditor = ({ doc, provider }: BlockNoteEditorProps) => {
   );
   useHeadings(editor);
 
+  /**
+   * With the collaboration it gets complicated to create the initial block
+   * better to let Blocknote manage, then we update the block with the content.
+   */
+  useEffect(() => {
+    if (doc.content) {
+      return;
+    }
+
+    setTimeout(() => {
+      editor.updateBlock(editor.document[0], {
+        type: 'heading',
+        content: '',
+      });
+    }, 100);
+  }, [editor, doc.content]);
+
   useEffect(() => {
     setEditor(editor);
 

--- a/src/frontend/apps/impress/src/features/docs/doc-management/stores/useDocStore.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/stores/useDocStore.tsx
@@ -2,7 +2,7 @@ import { HocuspocusProvider } from '@hocuspocus/provider';
 import * as Y from 'yjs';
 import { create } from 'zustand';
 
-import { Base64, Doc, blocksToYDoc } from '@/features/docs/doc-management';
+import { Base64, Doc } from '@/features/docs/doc-management';
 
 export interface UseDocStore {
   currentDoc?: Doc;
@@ -28,15 +28,6 @@ export const useDocStore = create<UseDocStore>((set, get) => ({
 
     if (initialDoc) {
       Y.applyUpdate(doc, Buffer.from(initialDoc, 'base64'));
-    } else {
-      const initialDocContent = [
-        {
-          type: 'heading',
-          content: '',
-        },
-      ];
-
-      blocksToYDoc(initialDocContent, doc);
     }
 
     const provider = new HocuspocusProvider({

--- a/src/frontend/apps/impress/src/features/docs/doc-management/utils.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/utils.ts
@@ -12,23 +12,6 @@ export const currentDocRole = (abilities: Doc['abilities']): Role => {
         : Role.READER;
 };
 
-type BasicBlock = {
-  type: string;
-  content: string;
-};
-export const blocksToYDoc = (blocks: BasicBlock[], doc: Y.Doc) => {
-  const xmlFragment = doc.getXmlFragment('document-store');
-
-  blocks.forEach((block) => {
-    const xmlElement = new Y.XmlElement(block.type);
-    if (block.content) {
-      xmlElement.insert(0, [new Y.XmlText(block.content)]);
-    }
-
-    xmlFragment.push([xmlElement]);
-  });
-};
-
 export const base64ToYDoc = (base64: string) => {
   const uint8Array = Buffer.from(base64, 'base64');
   const ydoc = new Y.Doc();


### PR DESCRIPTION
## Purpose

The initial document creation could create bug with collaboration. As soon as a char was enter and saved, this bug stopped to appear (basically after 1 mn).

The initial creation involving collaboration seems more complicated that what we were doing:
https://github.com/TypeCellOS/BlockNote/blob/71792c2fbdc99785cd8ce5b540d1a468e6c66131/packages/core/src/editor/BlockNoteTipTapEditor.ts#L73-L131

## Proposal

We will let Blocknote managing the initial creation, and we will update the Blocknote initial creation with our initial creation. 
Collaborating issue are gone, the document sync correctly between collaborators.
