### PR TITLE
✅(e2e) add a test on doc creation server side

### DIFF
--- a/env.d/development/common.e2e.dist
+++ b/env.d/development/common.e2e.dist
@@ -1,3 +1,6 @@
 # For the CI job test-e2e
 SUSTAINED_THROTTLE_RATES="200/hour"
 BURST_THROTTLE_RATES="200/minute"
+DJANGO_SERVER_TO_SERVER_API_TOKENS=test-e2e
+Y_PROVIDER_API_KEY=yprovider-api-key
+Y_PROVIDER_API_BASE_URL=http://y-provider:4444/api/

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-create.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-create.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { createDoc } from './common';
+import { createDoc, goToGridDoc, keyCloakSignIn, randomName } from './common';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/');
@@ -27,5 +27,49 @@ test.describe('Doc Create', () => {
     await expect(datagridTable.getByText(docTitle)).toBeVisible({
       timeout: 5000,
     });
+  });
+});
+
+test.describe('Doc Create: Not loggued', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('it creates a doc server way', async ({
+    page,
+    browserName,
+    request,
+  }) => {
+    const markdown = `This is a normal text\n\n# And this is a large heading`;
+    const [title] = randomName('My server way doc create', browserName, 1);
+    const data = {
+      title,
+      content: markdown,
+      sub: `user@${browserName}.e2e`,
+      email: `user@${browserName}.e2e`,
+    };
+
+    const newDoc = await request.post(
+      `http://localhost:8071/api/v1.0/documents/create-for-owner/`,
+      {
+        data,
+        headers: {
+          Authorization: 'Bearer test-e2e',
+          format: 'json',
+        },
+      },
+    );
+
+    expect(newDoc.ok()).toBeTruthy();
+
+    await keyCloakSignIn(page, browserName);
+
+    await goToGridDoc(page, { title });
+
+    await expect(page.getByRole('heading', { name: title })).toBeVisible();
+
+    const editor = page.locator('.ProseMirror');
+    await expect(editor.getByText('This is a normal text')).toBeVisible();
+    await expect(
+      editor.locator('h1').getByText('And this is a large heading'),
+    ).toBeVisible();
   });
 });


### PR DESCRIPTION
## Purpose

We recently added a new feature to the app, which is the ability to create a document from server to server.
`Server A` will send a request to `Server B` with a markdown content, and `Server B` will create the document after converting the markdown to yjs base64 format.
This test will check all the steps of the process and assert that the document is displayed correctly on the frontend in the blocknote editor.


