### PR TITLE
🔖(minor) release 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+
+## [1.10.0] - 2024-12-17
+
 ## Added
 
 - ✨(backend) add server-to-server API endpoint to create documents #467
 - ✨(email) white brand email #412
+- ✨(y-provider) create a markdown converter endpoint #488
 
 ## Changed
 
@@ -29,7 +33,6 @@ and this project adheres to
 
 - ✨(backend) annotate number of accesses on documents in list view #429
 - ✨(backend) allow users to mark/unmark documents as favorite #429
-- ✨(y-provider) create a markdown converter endpoint #488
 
 ## Changed
 
@@ -318,7 +321,8 @@ and this project adheres to
 - 🚀 Impress, project to manage your documents easily and collaboratively.
 
 
-[unreleased]: https://github.com/numerique-gouv/impress/compare/v1.9.0...main
+[unreleased]: https://github.com/numerique-gouv/impress/compare/v1.10.0...main
+[v1.10.0]: https://github.com/numerique-gouv/impress/releases/v1.10.0
 [v1.9.0]: https://github.com/numerique-gouv/impress/releases/v1.9.0
 [v1.8.2]: https://github.com/numerique-gouv/impress/releases/v1.8.2
 [v1.8.1]: https://github.com/numerique-gouv/impress/releases/v1.8.1

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "impress"
-version = "1.9.0"
+version = "1.10.0"
 authors = [{ "name" = "DINUM", "email" = "dev@mail.numerique.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/frontend/apps/e2e/package.json
+++ b/src/frontend/apps/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-e2e",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "scripts": {
     "lint": "eslint . --ext .ts",

--- a/src/frontend/apps/impress/package.json
+++ b/src/frontend/apps/impress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-impress",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "impress",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "workspaces": {
     "packages": [

--- a/src/frontend/packages/eslint-config-impress/package.json
+++ b/src/frontend/packages/eslint-config-impress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-impress",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "license": "MIT",
   "scripts": {
     "lint": "eslint --ext .js ."

--- a/src/frontend/packages/i18n/package.json
+++ b/src/frontend/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packages-i18n",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "scripts": {
     "extract-translation": "yarn extract-translation:impress",

--- a/src/frontend/servers/y-provider/package.json
+++ b/src/frontend/servers/y-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server-y-provider",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Y.js provider for docs",
   "repository": "https://github.com/numerique-gouv/impress",
   "license": "MIT",

--- a/src/helm/extra/Chart.yaml
+++ b/src/helm/extra/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: extra
 description: A Helm chart to add some manifests to impress
 type: application
-version: 1.9.0
+version: 1.10.0

--- a/src/helm/helmfile.yaml
+++ b/src/helm/helmfile.yaml
@@ -62,6 +62,6 @@ releases:
 environments:
   dev:
     values:
-      - version: 1.9.0
+      - version: 1.10.0
     secrets:
       - env.d/{{ .Environment.Name }}/secrets.enc.yaml

--- a/src/helm/impress/Chart.yaml
+++ b/src/helm/impress/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 type: application
 name: impress
-version: 1.9.0
+version: 1.10.0

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## What's new in Docs

## Added

- ✨(backend) add server-to-server API endpoint to create documents #467
- ✨(email) white brand email #412
- ✨(y-provider) create a markdown converter endpoint #488

## Changed

- ⚡️(docker) improve y-provider image #422

## Fixed

- ⚡️(e2e) reduce flakiness on e2e tests #511

## What's new about the editor: 

https://github.com/TypeCellOS/BlockNote/releases/tag/v0.21.0

---

**Full Changelog:** https://github.com/numerique-gouv/impress/compare/v1.9.0...v1.10.0