### PR TITLE
🔧(helm) add option to disable default tls setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Added
+
+🔧(helm) add option to disable default tls setting by @dominikkaminski #519
+
 
 ## [1.10.0] - 2024-12-17
 

--- a/src/helm/impress/templates/ingress.yaml
+++ b/src/helm/impress/templates/ingress.yaml
@@ -29,7 +29,7 @@ spec:
   {{- if .Values.ingress.tls.enabled }}
   tls:
     {{- if .Values.ingress.host }}
-    - secretName: {{ $fullName }}-tls
+    - secretName: {{ .Values.ingress.tls.secretName | default (printf "%s-tls" $fullName) | quote }}
       hosts:
         - {{ .Values.ingress.host | quote }}
     {{- end }}
@@ -115,4 +115,3 @@ spec:
           {{- end }}
     {{- end }}
 {{- end }}
-

--- a/src/helm/impress/templates/ingress_admin.yaml
+++ b/src/helm/impress/templates/ingress_admin.yaml
@@ -29,7 +29,7 @@ spec:
   {{- if .Values.ingressAdmin.tls.enabled }}
   tls:
     {{- if .Values.ingressAdmin.host }}
-    - secretName: {{ $fullName }}-tls
+    - secretName: {{ .Values.ingressAdmin.tls.secretName | default (printf "%s-tls" $fullName) | quote }}
       hosts:
         - {{ .Values.ingressAdmin.host | quote }}
     {{- end }}
@@ -95,4 +95,3 @@ spec:
             {{- end }}
     {{- end }}
 {{- end }}
-

--- a/src/helm/impress/templates/ingress_collaboration_api.yaml
+++ b/src/helm/impress/templates/ingress_collaboration_api.yaml
@@ -29,7 +29,7 @@ spec:
   {{- if .Values.ingressCollaborationApi.tls.enabled }}
   tls:
     {{- if .Values.ingressCollaborationApi.host }}
-    - secretName: {{ $fullName }}-tls
+    - secretName: {{ .Values.ingressCollaborationApi.tls.secretName | default (printf "%s-tls" $fullName) | quote }}
       hosts:
         - {{ .Values.ingressCollaborationApi.host | quote }}
     {{- end }}
@@ -69,4 +69,3 @@ spec:
           {{- end }}
     {{- end }}
 {{- end }}
-

--- a/src/helm/impress/templates/ingress_collaboration_ws.yaml
+++ b/src/helm/impress/templates/ingress_collaboration_ws.yaml
@@ -29,7 +29,7 @@ spec:
   {{- if .Values.ingressCollaborationWS.tls.enabled }}
   tls:
     {{- if .Values.ingressCollaborationWS.host }}
-    - secretName: {{ $fullName }}-tls
+    - secretName: {{ .Values.ingressCollaborationWS.tls.secretName | default (printf "%s-tls" $fullName) | quote }}
       hosts:
         - {{ .Values.ingressCollaborationWS.host | quote }}
     {{- end }}
@@ -69,4 +69,3 @@ spec:
           {{- end }}
     {{- end }}
 {{- end }}
-

--- a/src/helm/impress/templates/ingress_media.yaml
+++ b/src/helm/impress/templates/ingress_media.yaml
@@ -29,7 +29,7 @@ spec:
   {{- if .Values.ingressMedia.tls.enabled }}
   tls:
     {{- if .Values.ingressMedia.host }}
-    - secretName: {{ $fullName }}-tls
+    - secretName: {{ .Values.ingressMedia.tls.secretName | default (printf "%s-tls" $fullName) | quote }}
       hosts:
         - {{ .Values.ingressMedia.host | quote }}
     {{- end }}

--- a/src/helm/impress/values.yaml
+++ b/src/helm/impress/values.yaml
@@ -37,12 +37,14 @@ ingress:
   ## @param ingress.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
-  ## @param ingress.tls.enabled Wether to enable TLS for the Ingress
+  ## @param ingress.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingress.tls.secretName Secret name for TLS config
   ## @skip ingress.tls.additional
   ## @extra ingress.tls.additional[].secretName Secret name for additional TLS config
   ## @extra ingress.tls.additional[].hosts[] Hosts for additional TLS config
   tls:
     enabled: true
+    secretName: null
     additional: []
 
   ## @param ingress.customBackends Add custom backends to ingress
@@ -60,21 +62,23 @@ ingressCollaborationWS:
   ## @param ingress.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
-  ## @param ingressCollaborationWS.tls.enabled Wether to enable TLS for the Ingress
+  ## @param ingressCollaborationWS.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressCollaborationWS.tls.secretName Secret name for TLS config
   ## @skip ingressCollaborationWS.tls.additional
   ## @extra ingressCollaborationWS.tls.additional[].secretName Secret name for additional TLS config
   ## @extra ingressCollaborationWS.tls.additional[].hosts[] Hosts for additional TLS config
   tls:
     enabled: true
+    secretName: null
     additional: []
 
   ## @param ingressCollaborationWS.customBackends Add custom backends to ingress
   customBackends: []
 
-  annotations: 
+  annotations:
     nginx.ingress.kubernetes.io/auth-response-headers: "Authorization, X-Can-Edit, X-User-Id"
     nginx.ingress.kubernetes.io/auth-url: https://impress.example.com/api/v1.0/documents/collaboration-auth/
-    nginx.ingress.kubernetes.io/enable-websocket: "true" 
+    nginx.ingress.kubernetes.io/enable-websocket: "true"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
     nginx.ingress.kubernetes.io/upstream-hash-by: $arg_room
@@ -91,19 +95,22 @@ ingressCollaborationApi:
   ## @param ingress.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
-  ## @param ingressCollaborationApi.tls.enabled Wether to enable TLS for the Ingress
+  ## @param ingressCollaborationApi.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressCollaborationApi.tls.secretName Secret name for TLS config
   ## @skip ingressCollaborationApi.tls.additional
   ## @extra ingressCollaborationApi.tls.additional[].secretName Secret name for additional TLS config
   ## @extra ingressCollaborationApi.tls.additional[].hosts[] Hosts for additional TLS config
   tls:
     enabled: true
+    secretName: null
     additional: []
 
   ## @param ingressCollaborationApi.customBackends Add custom backends to ingress
   customBackends: []
 
-  annotations: 
+  annotations:
     nginx.ingress.kubernetes.io/upstream-hash-by: $arg_room
+
 
 ## @param ingressAdmin.enabled whether to enable the Ingress or not
 ## @param ingressAdmin.className IngressClass to use for the Ingress
@@ -117,12 +124,14 @@ ingressAdmin:
   ## @param ingressAdmin.hosts Additional host to configure for the Ingress
   hosts: [ ]
   #  - chart-example.local
-  ## @param ingressAdmin.tls.enabled Wether to enable TLS for the Ingress
+  ## @param ingressAdmin.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressAdmin.tls.secretName Secret name for TLS config
   ## @skip ingressAdmin.tls.additional
   ## @extra ingressAdmin.tls.additional[].secretName Secret name for additional TLS config
   ## @extra ingressAdmin.tls.additional[].hosts[] Hosts for additional TLS config
   tls:
     enabled: true
+    secretName: null
     additional: []
 
 ## @param ingressMedia.enabled whether to enable the Ingress or not
@@ -137,12 +146,14 @@ ingressMedia:
   ## @param ingressMedia.hosts Additional host to configure for the Ingress
   hosts: [ ]
   #  - chart-example.local
-  ## @param ingressMedia.tls.enabled Wether to enable TLS for the Ingress
+  ## @param ingressMedia.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressMedia.tls.secretName Secret name for TLS config
   ## @skip ingressMedia.tls.additional
   ## @extra ingressMedia.tls.additional[].secretName Secret name for additional TLS config
   ## @extra ingressMedia.tls.additional[].hosts[] Hosts for additional TLS config
   tls:
     enabled: true
+    secretName: null
     additional: []
 
   annotations:


### PR DESCRIPTION
## Purpose

This merge requests sets an option for those who uses impress with a different secretName in ingress.

This defaults does not change the current deployments.