### PR TITLE
fix(sentry): reduce tracesSampleRate

### DIFF
--- a/src/frontend/apps/impress/src/stores/useSentryStore.tsx
+++ b/src/frontend/apps/impress/src/stores/useSentryStore.tsx
@@ -25,7 +25,7 @@ export const useSentryStore = create<SentryState>((set, get) => ({
         release: packageJson.version,
         replaysSessionSampleRate: 0.1,
         replaysOnErrorSampleRate: 1.0,
-        tracesSampleRate: 1.0,
+        tracesSampleRate: 0.1,
       }),
     });
   },

--- a/src/frontend/servers/y-provider/src/services/sentry.ts
+++ b/src/frontend/servers/y-provider/src/services/sentry.ts
@@ -6,6 +6,6 @@ import { SENTRY_DSN } from '../env';
 Sentry.init({
   dsn: SENTRY_DSN,
   integrations: [nodeProfilingIntegration()],
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0.1,
   profilesSampleRate: 1.0,
 });


### PR DESCRIPTION
reduce `tracesSampleRate` due to +120k daily events on the shared sentry instance

<img width="1113" alt="Capture d’écran 2024-12-19 à 16 16 01" src="https://github.com/user-attachments/assets/06e4c2b0-19d8-430c-aec0-fb816a4113bb" />
