### PR TITLE
✨(backend) add option to configure list of required OIDC claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 
 ## Added
 
+🔧(backend) add option to configure list of required OIDC claims #525
 🔧(helm) add option to disable default tls setting by @dominikkaminski #519
 
 ## Changed

--- a/src/backend/core/authentication/backends.py
+++ b/src/backend/core/authentication/backends.py
@@ -57,6 +57,18 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
                     _("Invalid response format or token verification failed")
                 ) from e
 
+        # Validate required claims
+        missing_claims = [
+            claim
+            for claim in settings.USER_OIDC_REQUIRED_CLAIMS
+            if claim not in userinfo
+        ]
+        if missing_claims:
+            raise SuspiciousOperation(
+                _("Missing required claims in user info: %(claims)s")
+                % {"claims": ", ".join(missing_claims)}
+            )
+
         return userinfo
 
     def get_or_create_user(self, access_token, id_token, payload):

--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -474,6 +474,9 @@ class Base(Configuration):
         environ_prefix=None,
     )
 
+    USER_OIDC_REQUIRED_CLAIMS = values.ListValue(
+        default=[], environ_name="USER_OIDC_REQUIRED_CLAIMS", environ_prefix=None
+    )
     USER_OIDC_FIELDS_TO_FULLNAME = values.ListValue(
         default=["first_name", "last_name"],
         environ_name="USER_OIDC_FIELDS_TO_FULLNAME",


### PR DESCRIPTION
## Purpose

We want to be able to refuse connection for users who have missing claims from a list of required keys.

## Proposal

Add option to configure list of required OIDC claims: USER_OIDC_REQUIRED_CLAIMS.
Defaults to an empty list.